### PR TITLE
Adding support for RDMA cases for  pfcQueueGroupSize of 4

### DIFF
--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -14,7 +14,8 @@ from tests.common.snappi_tests.common_helpers import get_addrs_in_subnet, get_pe
 from tests.common.snappi_tests.snappi_helpers import SnappiFanoutManager, get_snappi_port_location
 from tests.common.snappi_tests.port import SnappiPortConfig, SnappiPortType
 from tests.common.helpers.assertions import pytest_assert
-from tests.snappi_tests.variables import dut_ip_start, snappi_ip_start, prefix_length
+from tests.snappi_tests.variables import dut_ip_start, snappi_ip_start, prefix_length, pfcQueueGroupSize, \
+    pfcQueueValueDict
 logger = logging.getLogger(__name__)
 
 
@@ -403,14 +404,27 @@ def snappi_testbed_config(conn_graph_facts, fanout_graph_facts,     # noqa F811
 
     pfc = l1_config.flow_control.ieee_802_1qbb
     pfc.pfc_delay = 0
-    pfc.pfc_class_0 = 0
-    pfc.pfc_class_1 = 1
-    pfc.pfc_class_2 = 2
-    pfc.pfc_class_3 = 3
-    pfc.pfc_class_4 = 4
-    pfc.pfc_class_5 = 5
-    pfc.pfc_class_6 = 6
-    pfc.pfc_class_7 = 7
+    if pfcQueueGroupSize == 8:
+        pfc.pfc_class_0 = 0
+        pfc.pfc_class_1 = 1
+        pfc.pfc_class_2 = 2
+        pfc.pfc_class_3 = 3
+        pfc.pfc_class_4 = 4
+        pfc.pfc_class_5 = 5
+        pfc.pfc_class_6 = 6
+        pfc.pfc_class_7 = 7
+    elif pfcQueueGroupSize == 4:
+        pfc.pfc_class_0 = pfcQueueValueDict[0]
+        pfc.pfc_class_1 = pfcQueueValueDict[1]
+        pfc.pfc_class_2 = pfcQueueValueDict[2]
+        pfc.pfc_class_3 = pfcQueueValueDict[3]
+        pfc.pfc_class_4 = pfcQueueValueDict[4]
+        pfc.pfc_class_5 = pfcQueueValueDict[5]
+        pfc.pfc_class_6 = pfcQueueValueDict[6]
+        pfc.pfc_class_7 = pfcQueueValueDict[7]
+
+    else:
+        pytest_assert(False, 'pfcQueueGroupSize value is not 4 or 8')
 
     port_config_list = []
 

--- a/tests/common/snappi_tests/traffic_generation.py
+++ b/tests/common/snappi_tests/traffic_generation.py
@@ -1,7 +1,7 @@
 """
 This module allows various snappi based tests to generate various traffic configurations.
 """
-
+import math
 import time
 import logging
 from tests.common.helpers.assertions import pytest_assert
@@ -12,6 +12,7 @@ from tests.common.snappi_tests.common_helpers import get_egress_queue_count, pfc
 from tests.common.snappi_tests.port import select_ports, select_tx_port
 from tests.common.snappi_tests.snappi_helpers import wait_for_arp, fetch_snappi_flow_metrics
 from tests.snappi_tests.variables import pfcQueueGroupSize, pfcQueueValueDict
+
 logger = logging.getLogger(__name__)
 
 SNAPPI_POLL_DELAY_SEC = 2
@@ -274,6 +275,24 @@ def generate_pause_flows(testbed_config,
     pause_flow.metrics.loss = True
 
 
+def clear_dut_interface_counters(duthost):
+    """
+    Clears the dut interface counter.
+    Args:
+        duthost (obj): DUT host object
+    """
+    duthost.command("sonic-clear counters \n")
+
+
+def clear_dut_que_counters(duthost):
+    """
+    Clears the dut que counter.
+    Args:
+        duthost (obj): DUT host object
+    """
+    duthost.command("sonic-clear queuecounters \n")
+
+
 def run_traffic(duthost,
                 api,
                 config,
@@ -293,20 +312,22 @@ def run_traffic(duthost,
         exp_dur_sec (int): experiment duration in second
         snappi_extra_params (SnappiTestParams obj): additional parameters for Snappi traffic
     Returns:
-        per-flow statistics (list)
+        flow_metrics (snappi metrics object): per-flow statistics from TGEN (right after flows end)
+        switch_device_results (dict): statistics from DUT on both TX and RX and per priority
+        in_flight_flow_metrics (snappi metrics object): in-flight statistics per flow from TGEN
+                                                        (right before flows end)
     """
 
     api.set_config(config)
-
     logger.info("Wait for Arp to Resolve ...")
     wait_for_arp(api, max_attempts=30, poll_interval_sec=2)
-
     pcap_type = snappi_extra_params.packet_capture_type
     base_flow_config = snappi_extra_params.base_flow_config
     switch_tx_lossless_prios = sum(base_flow_config["dut_port_config"][1].values(), [])
     switch_rx_port = snappi_extra_params.base_flow_config["tx_port_config"].peer_port
     switch_tx_port = snappi_extra_params.base_flow_config["rx_port_config"].peer_port
     switch_device_results = None
+    in_flight_flow_metrics = None
 
     if pcap_type != packet_capture.NO_CAPTURE:
         logger.info("Starting packet capture ...")
@@ -314,6 +335,10 @@ def run_traffic(duthost,
         cs.port_names = snappi_extra_params.packet_capture_ports
         cs.state = cs.START
         api.set_capture_state(cs)
+
+    clear_dut_interface_counters(duthost)
+
+    clear_dut_que_counters(duthost)
 
     logger.info("Starting transmit on all flows ...")
     ts = api.transmit_state()
@@ -332,7 +357,7 @@ def run_traffic(duthost,
         exp_dur_sec = exp_dur_sec + ANSIBLE_POLL_DELAY_SEC  # extra time to allow for device polling
         poll_freq_sec = int(exp_dur_sec / 10)
 
-        for _ in range(10):
+        for poll_iter in range(10):
             for lossless_prio in switch_tx_lossless_prios:
                 switch_device_results["tx_frames"][lossless_prio].append(get_egress_queue_count(duthost, switch_tx_port,
                                                                                                 lossless_prio)[0])
@@ -340,9 +365,21 @@ def run_traffic(duthost,
                                                                                                 lossless_prio)[0])
             time.sleep(poll_freq_sec)
 
+            if poll_iter == 5:
+                logger.info("Polling TGEN for in-flight traffic statistics...")
+                in_flight_flow_metrics = fetch_snappi_flow_metrics(api, all_flow_names)
+                flow_names = [metric.name for metric in in_flight_flow_metrics if metric.name in data_flow_names]
+                tx_frames = [metric.frames_tx for metric in in_flight_flow_metrics if metric.name in data_flow_names]
+                rx_frames = [metric.frames_rx for metric in in_flight_flow_metrics if metric.name in data_flow_names]
+                logger.info("In-flight traffic statistics for flows: {}".format(flow_names))
+                logger.info("In-flight TX frames: {}".format(tx_frames))
+                logger.info("In-flight RX frames: {}".format(rx_frames))
         logger.info("DUT polling complete")
     else:
-        time.sleep(exp_dur_sec)  # no polling required
+        time.sleep(exp_dur_sec*(2/5))  # no switch polling required, only TGEN polling
+        logger.info("Polling TGEN for in-flight traffic statistics...")
+        in_flight_flow_metrics = fetch_snappi_flow_metrics(api, all_flow_names)  # fetch in-flight metrics from TGEN
+        time.sleep(exp_dur_sec*(3/5))
 
     attempts = 0
     max_attempts = 20
@@ -385,7 +422,7 @@ def run_traffic(duthost,
     ts.state = ts.STOP
     api.set_transmit_state(ts)
 
-    return flow_metrics, switch_device_results
+    return flow_metrics, switch_device_results, in_flight_flow_metrics
 
 
 def verify_pause_flow(flow_metrics,
@@ -731,3 +768,80 @@ def verify_egress_queue_frame_count(duthost,
                 total_egress_packets, _ = get_egress_queue_count(duthost, peer_port, prios[prio])
                 pytest_assert(total_egress_packets == test_tx_frames[prio],
                               "Queue counters should increment for invalid PFC pause frames")
+
+
+def verify_m2o_oversubscribtion_results(duthost,
+                                        rows,
+                                        test_flow_name,
+                                        bg_flow_name,
+                                        rx_port,
+                                        rx_frame_count_deviation,
+                                        flag):
+    """
+    Verify if we get expected experiment results
+
+    Args:
+        duthost (obj): DUT host object
+        rows (list): per-flow statistics
+        test_flow_name (str): name of test flows
+        bg_flow_name (str): name of background flows
+        rx_port: Rx port of the dut
+        rx_frame_count_deviation (float): deviation for rx frame count (default to 1%)
+        flag (dict): Comprises of flow name and its loss criteria ,loss criteria value can be integer values
+                     of string type for definite results or 'continuing' for non definite loss value results
+                     example:{
+                                'Test Flow 1 -> 0 Rate:40': {
+                                    'loss': '0'
+                                },
+                                'PFC Pause': {
+                                    'loss': '100'
+                                },
+                                'Background Flow 1 -> 0 Rate:20': {
+                                    'loss': '5'
+                                },
+                                'Background Flow 2 -> 0 Rate:40': {
+                                    'loss': 'continuing'
+                                },
+                            }
+
+    Returns:
+        N/A
+    """
+
+    sum_rx = 0
+    for flow_type, criteria in flag.items():
+        for row in rows:
+            tx_frames = row.frames_tx
+            rx_frames = row.frames_rx
+            if flow_type in row.name:
+                try:
+                    if isinstance(criteria, dict) and isinstance(criteria['loss'], str) and int(criteria['loss']) == 0:
+                        logger.info('{}, TX Frames:{}, RX Frames:{}'.format(row.name, tx_frames, rx_frames))
+                        pytest_assert(tx_frames == rx_frames,
+                                      '{} should not have any dropped packet'.format(row.name))
+                        pytest_assert(row.loss == 0,
+                                      '{} should not have traffic loss'.format(row.name))
+                    elif (isinstance(criteria, dict) and isinstance(criteria['loss'], str)
+                          and int(criteria['loss']) != 0):
+                        pytest_assert(math.ceil(float(row.loss)) == float(flag[flow_type]['loss']) or
+                                      math.floor(float(row.loss)) == float(flag[flow_type]['loss']),
+                                      '{} should have traffic loss close to {} percent but got {}'.
+                                      format(row.name, float(flag[flow_type]['loss']), float(row.loss)))
+                    else:
+                        pytest_assert(False, 'Wrong criteria given in flag, accepted values are of type \
+                                      string for loss criteria')
+                except Exception:
+                    if (isinstance(criteria, dict) and isinstance(criteria['loss'], str)
+                       and criteria['loss'] == 'continuing'):
+                        pytest_assert(int(row.loss) > 0, "{} should have continuing traffic loss greater than 0".
+                                      format(row.name))
+                    else:
+                        pytest_assert(False, 'Wrong criteria given in flag, accepted values are of type \
+                                      string for loss criteria')
+            sum_rx += int(row.frames_rx)
+
+    tx_frames = get_tx_frame_count(duthost, rx_port['peer_port'])[0]
+    pytest_assert(abs(sum_rx - tx_frames)/sum_rx <= rx_frame_count_deviation,
+                  "FAIL: DUT counters doesn't match with the total frames received on Rx port, \
+                  Deviation of more than {} observed".format(rx_frame_count_deviation))
+    logger.info("PASS: DUT counters match with the total frames received on Rx port")

--- a/tests/common/snappi_tests/traffic_generation.py
+++ b/tests/common/snappi_tests/traffic_generation.py
@@ -1,7 +1,7 @@
 """
 This module allows various snappi based tests to generate various traffic configurations.
 """
-import math
+
 import time
 import logging
 from tests.common.helpers.assertions import pytest_assert
@@ -11,7 +11,7 @@ from tests.common.snappi_tests.common_helpers import get_egress_queue_count, pfc
     traffic_flow_mode
 from tests.common.snappi_tests.port import select_ports, select_tx_port
 from tests.common.snappi_tests.snappi_helpers import wait_for_arp, fetch_snappi_flow_metrics
-
+from tests.snappi_tests.variables import pfcQueueGroupSize, pfcQueueValueDict
 logger = logging.getLogger(__name__)
 
 SNAPPI_POLL_DELAY_SEC = 2
@@ -119,7 +119,10 @@ def generate_test_flows(testbed_config,
         eth, ipv4 = test_flow.packet.ethernet().ipv4()
         eth.src.value = base_flow_config["tx_mac"]
         eth.dst.value = base_flow_config["rx_mac"]
-        eth.pfc_queue.value = prio
+        if pfcQueueGroupSize == 8:
+            eth.pfc_queue.value = prio
+        else:
+            eth.pfc_queue.value = pfcQueueValueDict[prio]
 
         ipv4.src.value = base_flow_config["tx_port_config"].ip
         ipv4.dst.value = base_flow_config["rx_port_config"].ip
@@ -184,7 +187,10 @@ def generate_background_flows(testbed_config,
         eth, ipv4 = bg_flow.packet.ethernet().ipv4()
         eth.src.value = base_flow_config["tx_mac"]
         eth.dst.value = base_flow_config["rx_mac"]
-        eth.pfc_queue.value = prio
+        if pfcQueueGroupSize == 8:
+            eth.pfc_queue.value = prio
+        else:
+            eth.pfc_queue.value = pfcQueueValueDict[prio]
 
         ipv4.src.value = base_flow_config["tx_port_config"].ip
         ipv4.dst.value = base_flow_config["rx_port_config"].ip
@@ -268,24 +274,6 @@ def generate_pause_flows(testbed_config,
     pause_flow.metrics.loss = True
 
 
-def clear_dut_interface_counters(duthost):
-    """
-    Clears the dut interface counter.
-    Args:
-        duthost (obj): DUT host object
-    """
-    duthost.command("sonic-clear counters \n")
-
-
-def clear_dut_que_counters(duthost):
-    """
-    Clears the dut que counter.
-    Args:
-        duthost (obj): DUT host object
-    """
-    duthost.command("sonic-clear queuecounters \n")
-
-
 def run_traffic(duthost,
                 api,
                 config,
@@ -305,22 +293,20 @@ def run_traffic(duthost,
         exp_dur_sec (int): experiment duration in second
         snappi_extra_params (SnappiTestParams obj): additional parameters for Snappi traffic
     Returns:
-        flow_metrics (snappi metrics object): per-flow statistics from TGEN (right after flows end)
-        switch_device_results (dict): statistics from DUT on both TX and RX and per priority
-        in_flight_flow_metrics (snappi metrics object): in-flight statistics per flow from TGEN
-                                                        (right before flows end)
+        per-flow statistics (list)
     """
 
     api.set_config(config)
+
     logger.info("Wait for Arp to Resolve ...")
     wait_for_arp(api, max_attempts=30, poll_interval_sec=2)
+
     pcap_type = snappi_extra_params.packet_capture_type
     base_flow_config = snappi_extra_params.base_flow_config
     switch_tx_lossless_prios = sum(base_flow_config["dut_port_config"][1].values(), [])
     switch_rx_port = snappi_extra_params.base_flow_config["tx_port_config"].peer_port
     switch_tx_port = snappi_extra_params.base_flow_config["rx_port_config"].peer_port
     switch_device_results = None
-    in_flight_flow_metrics = None
 
     if pcap_type != packet_capture.NO_CAPTURE:
         logger.info("Starting packet capture ...")
@@ -328,10 +314,6 @@ def run_traffic(duthost,
         cs.port_names = snappi_extra_params.packet_capture_ports
         cs.state = cs.START
         api.set_capture_state(cs)
-
-    clear_dut_interface_counters(duthost)
-
-    clear_dut_que_counters(duthost)
 
     logger.info("Starting transmit on all flows ...")
     ts = api.transmit_state()
@@ -350,7 +332,7 @@ def run_traffic(duthost,
         exp_dur_sec = exp_dur_sec + ANSIBLE_POLL_DELAY_SEC  # extra time to allow for device polling
         poll_freq_sec = int(exp_dur_sec / 10)
 
-        for poll_iter in range(10):
+        for _ in range(10):
             for lossless_prio in switch_tx_lossless_prios:
                 switch_device_results["tx_frames"][lossless_prio].append(get_egress_queue_count(duthost, switch_tx_port,
                                                                                                 lossless_prio)[0])
@@ -358,21 +340,9 @@ def run_traffic(duthost,
                                                                                                 lossless_prio)[0])
             time.sleep(poll_freq_sec)
 
-            if poll_iter == 5:
-                logger.info("Polling TGEN for in-flight traffic statistics...")
-                in_flight_flow_metrics = fetch_snappi_flow_metrics(api, all_flow_names)
-                flow_names = [metric.name for metric in in_flight_flow_metrics if metric.name in data_flow_names]
-                tx_frames = [metric.frames_tx for metric in in_flight_flow_metrics if metric.name in data_flow_names]
-                rx_frames = [metric.frames_rx for metric in in_flight_flow_metrics if metric.name in data_flow_names]
-                logger.info("In-flight traffic statistics for flows: {}".format(flow_names))
-                logger.info("In-flight TX frames: {}".format(tx_frames))
-                logger.info("In-flight RX frames: {}".format(rx_frames))
         logger.info("DUT polling complete")
     else:
-        time.sleep(exp_dur_sec*(2/5))  # no switch polling required, only TGEN polling
-        logger.info("Polling TGEN for in-flight traffic statistics...")
-        in_flight_flow_metrics = fetch_snappi_flow_metrics(api, all_flow_names)  # fetch in-flight metrics from TGEN
-        time.sleep(exp_dur_sec*(3/5))
+        time.sleep(exp_dur_sec)  # no polling required
 
     attempts = 0
     max_attempts = 20
@@ -415,7 +385,7 @@ def run_traffic(duthost,
     ts.state = ts.STOP
     api.set_transmit_state(ts)
 
-    return flow_metrics, switch_device_results, in_flight_flow_metrics
+    return flow_metrics, switch_device_results
 
 
 def verify_pause_flow(flow_metrics,
@@ -761,80 +731,3 @@ def verify_egress_queue_frame_count(duthost,
                 total_egress_packets, _ = get_egress_queue_count(duthost, peer_port, prios[prio])
                 pytest_assert(total_egress_packets == test_tx_frames[prio],
                               "Queue counters should increment for invalid PFC pause frames")
-
-
-def verify_m2o_oversubscribtion_results(duthost,
-                                        rows,
-                                        test_flow_name,
-                                        bg_flow_name,
-                                        rx_port,
-                                        rx_frame_count_deviation,
-                                        flag):
-    """
-    Verify if we get expected experiment results
-
-    Args:
-        duthost (obj): DUT host object
-        rows (list): per-flow statistics
-        test_flow_name (str): name of test flows
-        bg_flow_name (str): name of background flows
-        rx_port: Rx port of the dut
-        rx_frame_count_deviation (float): deviation for rx frame count (default to 1%)
-        flag (dict): Comprises of flow name and its loss criteria ,loss criteria value can be integer values
-                     of string type for definite results or 'continuing' for non definite loss value results
-                     example:{
-                                'Test Flow 1 -> 0 Rate:40': {
-                                    'loss': '0'
-                                },
-                                'PFC Pause': {
-                                    'loss': '100'
-                                },
-                                'Background Flow 1 -> 0 Rate:20': {
-                                    'loss': '5'
-                                },
-                                'Background Flow 2 -> 0 Rate:40': {
-                                    'loss': 'continuing'
-                                },
-                            }
-
-    Returns:
-        N/A
-    """
-
-    sum_rx = 0
-    for flow_type, criteria in flag.items():
-        for row in rows:
-            tx_frames = row.frames_tx
-            rx_frames = row.frames_rx
-            if flow_type in row.name:
-                try:
-                    if isinstance(criteria, dict) and isinstance(criteria['loss'], str) and int(criteria['loss']) == 0:
-                        logger.info('{}, TX Frames:{}, RX Frames:{}'.format(row.name, tx_frames, rx_frames))
-                        pytest_assert(tx_frames == rx_frames,
-                                      '{} should not have any dropped packet'.format(row.name))
-                        pytest_assert(row.loss == 0,
-                                      '{} should not have traffic loss'.format(row.name))
-                    elif (isinstance(criteria, dict) and isinstance(criteria['loss'], str)
-                          and int(criteria['loss']) != 0):
-                        pytest_assert(math.ceil(float(row.loss)) == float(flag[flow_type]['loss']) or
-                                      math.floor(float(row.loss)) == float(flag[flow_type]['loss']),
-                                      '{} should have traffic loss close to {} percent but got {}'.
-                                      format(row.name, float(flag[flow_type]['loss']), float(row.loss)))
-                    else:
-                        pytest_assert(False, 'Wrong criteria given in flag, accepted values are of type \
-                                      string for loss criteria')
-                except Exception:
-                    if (isinstance(criteria, dict) and isinstance(criteria['loss'], str)
-                       and criteria['loss'] == 'continuing'):
-                        pytest_assert(int(row.loss) > 0, "{} should have continuing traffic loss greater than 0".
-                                      format(row.name))
-                    else:
-                        pytest_assert(False, 'Wrong criteria given in flag, accepted values are of type \
-                                      string for loss criteria')
-            sum_rx += int(row.frames_rx)
-
-    tx_frames = get_tx_frame_count(duthost, rx_port['peer_port'])[0]
-    pytest_assert(abs(sum_rx - tx_frames)/sum_rx <= rx_frame_count_deviation,
-                  "FAIL: DUT counters doesn't match with the total frames received on Rx port, \
-                  Deviation of more than {} observed".format(rx_frame_count_deviation))
-    logger.info("PASS: DUT counters match with the total frames received on Rx port")

--- a/tests/snappi_tests/variables.py
+++ b/tests/snappi_tests/variables.py
@@ -52,3 +52,14 @@ config_set = {
 dut_ip_start = '20.0.1.1'
 snappi_ip_start = '20.0.1.2'
 prefix_length = 24
+
+
+pfcQueueGroupSize = 8  # can have values 4 or 8
+pfcQueueValueDict = {0: 0,
+                     1: 1,
+                     2: 0,
+                     3: 3,
+                     4: 2,
+                     5: 0,
+                     6: 1,
+                     7: 0}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Adding support for RDMA cases for  pfcQueueGroupSize of 4 to support AresOne card type
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
Indorder to support rdma cases to run on AresOne which supports pfcQueueGroupSize of 4
#### How did you do it?
Added pfcQueueGroupSize and pfcQueueValueDict variables in variables.py file
#### How did you verify/test it?
Tested on Arista dut
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?
t0,t1,t2
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
### Output

AzDevOps@8e6233df64b9:~/sonic-mgmt/tests$ py.test --inventory ../ansible/snappi-sonic --host-pattern sonic-s6100-dut1 --testbed vms-snappi-sonic-multidut --testbed_file ../ansible/testbed.csv --show-capture=stdout --log-cli-level info --showlocals -ra --allow_recover --skip_sanity --disable_loganalyzer snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py
=============================================================================================== test session starts ================================================================================================
platform linux -- Python 3.8.10, pytest-7.4.0, pluggy-1.3.0
ansible: 2.13.13
rootdir: /var/AzDevOps/sonic-mgmt/tests
configfile: pytest.ini
plugins: allure-pytest-2.8.22, ansible-4.0.0, forked-1.6.0, html-4.1.0, metadata-3.0.0, repeat-0.9.3, xdist-1.28.0
collecting 11 items                                                                                                                                                                                                
----------------------------------------------------------------------------------------------- live log collection ------------------------------------------------------------------------------------------------
18:26:37 __init__.pytest_collection_modifyitems   L0581 INFO   | Available basic facts that can be used in conditional skip:
{
  "topo_type": "ptf",
  "topo_name": "ptf64",
  "testbed": "vms-snappi-sonic-multidut"
}
collected 11 items                                                                                                                                                                                                 

snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py::test_pfc_pause_single_lossless_prio[sonic-s6100-dut1|3] 
-------------------------------------------------------------------------------------------------- live log setup --------------------------------------------------------------------------------------------------
18:26:37 __init__.set_default                     L0053 INFO   | Completeness level not set during test execution. Setting to default level: CompletenessLevel.basic
18:26:37 __init__.check_test_completeness         L0152 INFO   | Test has no defined levels. Continue without test completeness checks
18:27:02 ptfhost_utils.run_icmp_responder_session L0239 INFO   | Skip running icmp_responder at session level, it is only for dualtor testbed with active-active mux ports.
18:27:02 conftest.creds_on_dut                    L0726 INFO   | dut sonic-s6100-dut1 belongs to groups ['snappi-sonic', 'sonic', 'sonic_dell64_40', 'fanout']
18:27:02 conftest.creds_on_dut                    L0750 INFO   | skip empty var file ../ansible/group_vars/all/corefile_uploader.yml
18:27:02 conftest.creds_on_dut                    L0750 INFO   | skip empty var file ../ansible/group_vars/all/env.yml
18:27:02 conftest.nbrhosts                        L0542 INFO   | No VMs exist for this topology: ptf64
18:27:02 conftest.core_dump_and_config_check      L2057 INFO   | Dumping Disk and Memory Space informataion before test on sonic-s6100-dut1
18:27:04 conftest.core_dump_and_config_check      L2061 INFO   | Collecting core dumps before test on sonic-s6100-dut1
18:27:05 conftest.core_dump_and_config_check      L2070 INFO   | Collecting running config before test on sonic-s6100-dut1
18:27:13 __init__.sanity_check                    L0125 INFO   | Skip sanity check according to command line argument
18:27:13 conftest.generate_params_dut_hostname    L1132 INFO   | Using DUTs ['sonic-s6100-dut1'] in testbed 'vms-snappi-sonic-multidut'
18:27:13 conftest.rand_one_dut_hostname           L0399 INFO   | Randomly select dut sonic-s6100-dut1 for testing
18:27:13 __init__._fixture_generator_decorator    L0081 INFO   | -------------------- fixture enable_packet_aging_after_test setup starts --------------------
18:27:13 __init__._fixture_generator_decorator    L0085 INFO   | -------------------- fixture enable_packet_aging_after_test setup ends --------------------
18:27:13 __init__._fixture_generator_decorator    L0081 INFO   | -------------------- fixture rand_lossless_prio setup starts --------------------
18:27:13 __init__._fixture_generator_decorator    L0085 INFO   | -------------------- fixture rand_lossless_prio setup ends --------------------
18:27:13 __init__._fixture_generator_decorator    L0081 INFO   | -------------------- fixture rand_lossy_prio setup starts --------------------
18:27:13 __init__._fixture_generator_decorator    L0085 INFO   | -------------------- fixture rand_lossy_prio setup ends --------------------
18:27:13 __init__._fixture_generator_decorator    L0081 INFO   | -------------------- fixture start_pfcwd_after_test setup starts --------------------
18:27:13 __init__._fixture_generator_decorator    L0085 INFO   | -------------------- fixture start_pfcwd_after_test setup ends --------------------
18:27:13 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture snappi_api_serv_ip setup starts --------------------
18:27:13 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture snappi_api_serv_ip setup ends --------------------
18:27:13 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture snappi_api_serv_port setup starts --------------------
18:27:13 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture snappi_api_serv_port setup ends --------------------
18:27:13 __init__._fixture_generator_decorator    L0081 INFO   | -------------------- fixture snappi_api setup starts --------------------
18:27:13 __init__._fixture_generator_decorator    L0085 INFO   | -------------------- fixture snappi_api setup ends --------------------
18:27:13 conftest.generate_port_lists             L1201 INFO   | Generate dut_port_map: {'sonic-s6100-dut1': ['sonic-s6100-dut1|Ethernet0', 'sonic-s6100-dut1|Ethernet4', 'sonic-s6100-dut1|Ethernet8', 'sonic-s6100-dut1|Ethernet12']}
18:27:13 conftest.generate_port_lists             L1224 INFO   | Generate port_list: ['sonic-s6100-dut1|Ethernet0', 'sonic-s6100-dut1|Ethernet4', 'sonic-s6100-dut1|Ethernet8', 'sonic-s6100-dut1|Ethernet12']
18:27:13 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture prio_dscp_map setup starts --------------------
18:27:15 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture prio_dscp_map setup ends --------------------
18:27:15 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture all_prio_list setup starts --------------------
18:27:15 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture all_prio_list setup ends --------------------
18:27:15 __init__.loganalyzer                     L0051 INFO   | Log analyzer is disabled
18:27:15 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture snappi_testbed_config setup starts --------------------
18:27:16 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture snappi_testbed_config setup ends --------------------
-------------------------------------------------------------------------------------------------- live log call ---------------------------------------------------------------------------------------------------
18:27:27 connection._warn                         L0246 WARNING| Verification of certificates is disabled
18:27:27 connection._info                         L0243 INFO   | Determining the platform and rest_port using the 10.36.78.2 address...
18:27:27 connection._warn                         L0246 WARNING| Unable to connect to http://10.36.78.2:443.
18:27:27 connection._info                         L0243 INFO   | Connection established to `https://10.36.78.2:443 on linux`
18:28:03 connection._info                         L0243 INFO   | Using IxNetwork api server version 9.30.2305.4
18:28:03 connection._info                         L0243 INFO   | User info IxNetwork/ixnetworkweb/admin-53-25157
18:28:05 snappi_api.info                          L1133 INFO   | snappi-0.9.1
18:28:05 snappi_api.info                          L1133 INFO   | snappi_ixnetwork-0.8.2
18:28:05 snappi_api.info                          L1133 INFO   | ixnetwork_restpy-1.0.64
18:28:06 snappi_api.info                          L1133 INFO   | Config validation 0.023s
18:28:11 snappi_api.info                          L1133 INFO   | Ports configuration 3.095s
18:28:11 snappi_api.info                          L1133 INFO   | Captures configuration 0.614s
18:28:16 snappi_api.info                          L1133 INFO   | Add location hosts [10.36.78.53] 2.672s
18:28:22 snappi_api.info                          L1133 INFO   | Location hosts ready [10.36.78.53] 6.903s
18:28:24 snappi_api.info                          L1133 INFO   | Speed conversion is not require for (port.name, speed) : [('Port 0', 'novusHundredGigNonFanOut'), ('Port 1', 'novusHundredGigNonFanOut'), ('Port 2', 'novusHundredGigNonFanOut'), ('Port 3', 'novusHundredGigNonFanOut')]
18:28:24 snappi_api.info                          L1133 INFO   | Aggregation mode speed change 1.283s
18:28:35 snappi_api.info                          L1133 INFO   | Location preemption [10.36.78.53;6;1, 10.36.78.53;6;2, 10.36.78.53;6;3, 10.36.78.53;6;4] 0.442s
18:29:01 snappi_api.info                          L1133 INFO   | Location connect [Port 0, Port 1, Port 2, Port 3] 25.662s
18:29:04 snappi_api.warning                       L1139 WARNING| Port 0 connectedLinkDown
18:29:04 snappi_api.warning                       L1139 WARNING| Port 1 connectedLinkDown
18:29:04 snappi_api.warning                       L1139 WARNING| Port 2 connectedLinkDown
18:29:04 snappi_api.warning                       L1139 WARNING| Port 3 connectedLinkDown
18:29:04 snappi_api.info                          L1133 INFO   | Location state check [Port 0, Port 1, Port 2, Port 3] 3.118s
18:29:04 snappi_api.info                          L1133 INFO   | Location configuration 52.563s
18:29:24 snappi_api.info                          L1133 INFO   | Layer1 configuration 20.019s
18:29:24 snappi_api.info                          L1133 INFO   | Lag Configuration 0.210s
18:29:25 snappi_api.info                          L1133 INFO   | Convert device config : 0.489s
18:29:25 snappi_api.info                          L1133 INFO   | Create IxNetwork device config : 0.000s
18:29:26 snappi_api.info                          L1133 INFO   | Push IxNetwork device config : 1.273s
18:29:26 snappi_api.info                          L1133 INFO   | Devices configuration 1.918s
18:29:40 snappi_api.info                          L1133 INFO   | Flows configuration 13.647s
18:29:51 snappi_api.info                          L1133 INFO   | Start interfaces 11.113s
18:29:52 snappi_api.info                          L1133 INFO   | IxNet - The Traffic Item was modified. Please perform a Traffic Generate to update the associated traffic Flow Groups
18:29:52 traffic_generation.run_traffic           L0301 INFO   | Wait for Arp to Resolve ...
18:29:56 traffic_generation.run_traffic           L0318 INFO   | Starting transmit on all flows ...
18:30:02 snappi_api.info                          L1133 INFO   | Flows generate/apply 4.852s
18:30:14 snappi_api.info                          L1133 INFO   | Flows clear statistics 12.049s
18:30:14 snappi_api.info                          L1133 INFO   | Captures start 0.000s
18:30:17 snappi_api.info                          L1133 INFO   | Flows start 2.771s
18:30:18 traffic_generation.run_traffic           L0325 INFO   | Polling DUT for traffic statistics for 23 seconds ...
18:31:24 traffic_generation.run_traffic           L0343 INFO   | DUT polling complete
18:31:24 traffic_generation.run_traffic           L0351 INFO   | Checking if all flows have stopped. Attempt #1
18:31:28 traffic_generation.run_traffic           L0358 INFO   | All test and background traffic flows stopped
18:31:30 traffic_generation.run_traffic           L0381 INFO   | Dumping per-flow statistics
18:31:33 traffic_generation.run_traffic           L0383 INFO   | Stopping transmit on all remaining flows
18:31:39 snappi_api.info                          L1133 INFO   | Flows stop 6.009s
PASSED                                                                                                                                                                                                       [  9%]
snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py::test_pfc_pause_single_lossless_prio[sonic-s6100-dut1|4] 
-------------------------------------------------------------------------------------------------- live log setup --------------------------------------------------------------------------------------------------
18:31:47 __init__.set_default                     L0053 INFO   | Completeness level not set during test execution. Setting to default level: CompletenessLevel.basic
18:31:47 __init__.check_test_completeness         L0152 INFO   | Test has no defined levels. Continue without test completeness checks
18:31:47 __init__.loganalyzer                     L0051 INFO   | Log analyzer is disabled
18:31:47 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture snappi_testbed_config setup starts --------------------
18:31:48 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture snappi_testbed_config setup ends --------------------
-------------------------------------------------------------------------------------------------- live log call ---------------------------------------------------------------------------------------------------
18:31:58 snappi_api.info                          L1133 INFO   | Config validation 0.026s
18:32:01 snappi_api.info                          L1133 INFO   | Ports configuration 0.537s
18:32:01 snappi_api.info                          L1133 INFO   | Captures configuration 0.351s
18:32:12 snappi_api.info                          L1133 INFO   | Location hosts ready [10.36.78.53] 2.165s
18:32:12 snappi_api.info                          L1133 INFO   | Speed change not require due to redundant Layer1 config
18:32:12 snappi_api.info                          L1133 INFO   | Aggregation mode speed change 0.013s
18:32:12 snappi_api.info                          L1133 INFO   | Location configuration 11.382s
18:32:28 snappi_api.info                          L1133 INFO   | Layer1 configuration 16.038s
18:32:29 snappi_api.info                          L1133 INFO   | Lag Configuration 0.157s
18:32:30 snappi_api.info                          L1133 INFO   | Convert device config : 1.360s
18:32:30 snappi_api.info                          L1133 INFO   | Create IxNetwork device config : 0.000s
18:32:31 snappi_api.info                          L1133 INFO   | Push IxNetwork device config : 0.504s
18:32:31 snappi_api.info                          L1133 INFO   | Devices configuration 2.028s
18:32:45 snappi_api.info                          L1133 INFO   | Flows configuration 14.312s
18:32:52 snappi_api.info                          L1133 INFO   | Start interfaces 6.643s
18:32:53 snappi_api.info                          L1133 INFO   | IxNet - The Traffic Item was modified. Please perform a Traffic Generate to update the associated traffic Flow Groups
18:32:53 traffic_generation.run_traffic           L0301 INFO   | Wait for Arp to Resolve ...
18:32:56 traffic_generation.run_traffic           L0318 INFO   | Starting transmit on all flows ...
18:32:59 snappi_api.info                          L1133 INFO   | Flows generate/apply 1.308s
18:33:11 snappi_api.info                          L1133 INFO   | Flows clear statistics 12.420s
18:33:11 snappi_api.info                          L1133 INFO   | Captures start 0.000s
18:33:15 snappi_api.info                          L1133 INFO   | Flows start 2.772s
18:33:15 traffic_generation.run_traffic           L0325 INFO   | Polling DUT for traffic statistics for 27 seconds ...
18:34:31 traffic_generation.run_traffic           L0343 INFO   | DUT polling complete
18:34:31 traffic_generation.run_traffic           L0351 INFO   | Checking if all flows have stopped. Attempt #1
18:34:34 traffic_generation.run_traffic           L0358 INFO   | All test and background traffic flows stopped
18:34:36 traffic_generation.run_traffic           L0381 INFO   | Dumping per-flow statistics
18:34:39 traffic_generation.run_traffic           L0383 INFO   | Stopping transmit on all remaining flows
18:34:47 snappi_api.info                          L1133 INFO   | Flows stop 6.567s
PASSED                                                                                                                                                                                                       [ 18%]
snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py::test_pfc_pause_counter_check[sonic-s6100-dut1|3] 
-------------------------------------------------------------------------------------------------- live log setup --------------------------------------------------------------------------------------------------
18:34:54 __init__.set_default                     L0053 INFO   | Completeness level not set during test execution. Setting to default level: CompletenessLevel.basic
18:34:54 __init__.check_test_completeness         L0152 INFO   | Test has no defined levels. Continue without test completeness checks
18:34:54 __init__.loganalyzer                     L0051 INFO   | Log analyzer is disabled
18:34:54 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture snappi_testbed_config setup starts --------------------
18:34:55 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture snappi_testbed_config setup ends --------------------
-------------------------------------------------------------------------------------------------- live log call ---------------------------------------------------------------------------------------------------
18:35:06 snappi_api.info                          L1133 INFO   | Config validation 0.010s
18:35:08 snappi_api.info                          L1133 INFO   | Ports configuration 0.565s
18:35:08 snappi_api.info                          L1133 INFO   | Captures configuration 0.334s
18:35:19 snappi_api.info                          L1133 INFO   | Location hosts ready [10.36.78.53] 2.172s
18:35:19 snappi_api.info                          L1133 INFO   | Speed change not require due to redundant Layer1 config
18:35:19 snappi_api.info                          L1133 INFO   | Aggregation mode speed change 0.010s
18:35:20 snappi_api.info                          L1133 INFO   | Location configuration 11.399s
18:35:35 snappi_api.info                          L1133 INFO   | Layer1 configuration 15.117s
18:35:35 snappi_api.info                          L1133 INFO   | Lag Configuration 0.159s
18:35:36 snappi_api.info                          L1133 INFO   | Convert device config : 1.382s
18:35:36 snappi_api.info                          L1133 INFO   | Create IxNetwork device config : 0.000s
18:35:37 snappi_api.info                          L1133 INFO   | Push IxNetwork device config : 0.544s
18:35:37 snappi_api.info                          L1133 INFO   | Devices configuration 2.087s
18:35:42 snappi_api.info                          L1133 INFO   | Flows configuration 4.866s
18:35:47 snappi_api.info                          L1133 INFO   | Start interfaces 5.120s
18:35:48 snappi_api.info                          L1133 INFO   | IxNet - The Traffic Item was modified. Please perform a Traffic Generate to update the associated traffic Flow Groups
18:35:48 traffic_generation.run_traffic           L0301 INFO   | Wait for Arp to Resolve ...
18:35:52 traffic_generation.run_traffic           L0318 INFO   | Starting transmit on all flows ...
18:35:57 snappi_api.info                          L1133 INFO   | Flows generate/apply 4.069s
18:36:09 snappi_api.info                          L1133 INFO   | Flows clear statistics 12.161s
18:36:09 snappi_api.info                          L1133 INFO   | Captures start 0.000s
18:36:13 snappi_api.info                          L1133 INFO   | Flows start 2.885s
18:36:13 traffic_generation.run_traffic           L0325 INFO   | Polling DUT for traffic statistics for 31 seconds ...
18:37:30 traffic_generation.run_traffic           L0343 INFO   | DUT polling complete
18:37:30 traffic_generation.run_traffic           L0351 INFO   | Checking if all flows have stopped. Attempt #1
18:37:33 traffic_generation.run_traffic           L0358 INFO   | All test and background traffic flows stopped
18:37:35 traffic_generation.run_traffic           L0381 INFO   | Dumping per-flow statistics
18:37:37 traffic_generation.run_traffic           L0383 INFO   | Stopping transmit on all remaining flows
18:37:45 snappi_api.info                          L1133 INFO   | Flows stop 6.613s
PASSED                                                                                                                                                                                                       [ 27%]
snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py::test_pfc_pause_counter_check[sonic-s6100-dut1|4] 
-------------------------------------------------------------------------------------------------- live log setup --------------------------------------------------------------------------------------------------
18:38:04 __init__.set_default                     L0053 INFO   | Completeness level not set during test execution. Setting to default level: CompletenessLevel.basic
18:38:04 __init__.check_test_completeness         L0152 INFO   | Test has no defined levels. Continue without test completeness checks
18:38:04 __init__.loganalyzer                     L0051 INFO   | Log analyzer is disabled
18:38:04 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture snappi_testbed_config setup starts --------------------
18:38:05 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture snappi_testbed_config setup ends --------------------
-------------------------------------------------------------------------------------------------- live log call ---------------------------------------------------------------------------------------------------
18:38:14 snappi_api.info                          L1133 INFO   | Config validation 0.013s
18:38:17 snappi_api.info                          L1133 INFO   | Ports configuration 0.586s
18:38:17 snappi_api.info                          L1133 INFO   | Captures configuration 0.427s
18:38:28 snappi_api.info                          L1133 INFO   | Location hosts ready [10.36.78.53] 2.199s
18:38:28 snappi_api.info                          L1133 INFO   | Speed change not require due to redundant Layer1 config
18:38:28 snappi_api.info                          L1133 INFO   | Aggregation mode speed change 0.011s
18:38:28 snappi_api.info                          L1133 INFO   | Location configuration 11.407s
18:38:48 snappi_api.info                          L1133 INFO   | Layer1 configuration 19.150s
18:38:48 snappi_api.info                          L1133 INFO   | Lag Configuration 0.253s
18:38:49 snappi_api.info                          L1133 INFO   | Convert device config : 1.309s
18:38:49 snappi_api.info                          L1133 INFO   | Create IxNetwork device config : 0.000s
18:38:50 snappi_api.info                          L1133 INFO   | Push IxNetwork device config : 0.575s
18:38:50 snappi_api.info                          L1133 INFO   | Devices configuration 2.050s
18:38:55 snappi_api.info                          L1133 INFO   | Flows configuration 4.644s
18:39:00 snappi_api.info                          L1133 INFO   | Start interfaces 5.033s
18:39:01 snappi_api.info                          L1133 INFO   | IxNet - The Traffic Item was modified. Please perform a Traffic Generate to update the associated traffic Flow Groups
18:39:01 traffic_generation.run_traffic           L0301 INFO   | Wait for Arp to Resolve ...
18:39:05 traffic_generation.run_traffic           L0318 INFO   | Starting transmit on all flows ...
18:39:08 snappi_api.info                          L1133 INFO   | Flows generate/apply 1.912s
18:39:20 snappi_api.info                          L1133 INFO   | Flows clear statistics 12.301s
18:39:20 snappi_api.info                          L1133 INFO   | Captures start 0.000s
18:39:24 snappi_api.info                          L1133 INFO   | Flows start 2.955s
18:39:24 traffic_generation.run_traffic           L0325 INFO   | Polling DUT for traffic statistics for 35 seconds ...
18:40:41 traffic_generation.run_traffic           L0343 INFO   | DUT polling complete
18:40:41 traffic_generation.run_traffic           L0351 INFO   | Checking if all flows have stopped. Attempt #1
18:40:44 traffic_generation.run_traffic           L0358 INFO   | All test and background traffic flows stopped
18:40:46 traffic_generation.run_traffic           L0381 INFO   | Dumping per-flow statistics
18:40:49 traffic_generation.run_traffic           L0383 INFO   | Stopping transmit on all remaining flows
18:40:56 snappi_api.info                          L1133 INFO   | Flows stop 6.578s
PASSED                                                                                                                                                                                                       [ 36%]
snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py::test_pfc_pause_multi_lossless_prio 
-------------------------------------------------------------------------------------------------- live log setup --------------------------------------------------------------------------------------------------
18:41:15 __init__.set_default                     L0053 INFO   | Completeness level not set during test execution. Setting to default level: CompletenessLevel.basic
18:41:15 __init__.check_test_completeness         L0152 INFO   | Test has no defined levels. Continue without test completeness checks
18:41:15 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture lossless_prio_list setup starts --------------------
18:41:16 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture lossless_prio_list setup ends --------------------
18:41:16 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture lossy_prio_list setup starts --------------------
18:41:16 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture lossy_prio_list setup ends --------------------
18:41:16 __init__.loganalyzer                     L0051 INFO   | Log analyzer is disabled
18:41:16 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture snappi_testbed_config setup starts --------------------
18:41:17 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture snappi_testbed_config setup ends --------------------
-------------------------------------------------------------------------------------------------- live log call ---------------------------------------------------------------------------------------------------
18:41:27 snappi_api.info                          L1133 INFO   | Config validation 0.026s
18:41:30 snappi_api.info                          L1133 INFO   | Ports configuration 0.510s
18:41:30 snappi_api.info                          L1133 INFO   | Captures configuration 0.339s
18:41:41 snappi_api.info                          L1133 INFO   | Location hosts ready [10.36.78.53] 2.170s
18:41:41 snappi_api.info                          L1133 INFO   | Speed change not require due to redundant Layer1 config
18:41:41 snappi_api.info                          L1133 INFO   | Aggregation mode speed change 0.014s
18:41:41 snappi_api.info                          L1133 INFO   | Location configuration 11.406s
18:41:59 snappi_api.info                          L1133 INFO   | Layer1 configuration 18.064s
18:42:00 snappi_api.info                          L1133 INFO   | Lag Configuration 0.155s
18:42:01 snappi_api.info                          L1133 INFO   | Convert device config : 1.370s
18:42:01 snappi_api.info                          L1133 INFO   | Create IxNetwork device config : 0.000s
18:42:02 snappi_api.info                          L1133 INFO   | Push IxNetwork device config : 0.541s
18:42:02 snappi_api.info                          L1133 INFO   | Devices configuration 2.067s
18:42:15 snappi_api.info                          L1133 INFO   | Flows configuration 12.821s
18:42:20 snappi_api.info                          L1133 INFO   | Start interfaces 4.849s
18:42:20 snappi_api.info                          L1133 INFO   | IxNet - The Traffic Item was modified. Please perform a Traffic Generate to update the associated traffic Flow Groups
18:42:20 traffic_generation.run_traffic           L0301 INFO   | Wait for Arp to Resolve ...
18:42:24 traffic_generation.run_traffic           L0318 INFO   | Starting transmit on all flows ...
18:42:27 snappi_api.info                          L1133 INFO   | Flows generate/apply 2.034s
18:42:40 snappi_api.info                          L1133 INFO   | Flows clear statistics 12.115s
18:42:40 snappi_api.info                          L1133 INFO   | Captures start 0.000s
18:42:43 snappi_api.info                          L1133 INFO   | Flows start 2.951s
18:42:43 traffic_generation.run_traffic           L0325 INFO   | Polling DUT for traffic statistics for 39 seconds ...
18:44:56 traffic_generation.run_traffic           L0343 INFO   | DUT polling complete
18:44:56 traffic_generation.run_traffic           L0351 INFO   | Checking if all flows have stopped. Attempt #1
18:44:59 traffic_generation.run_traffic           L0358 INFO   | All test and background traffic flows stopped
18:45:01 traffic_generation.run_traffic           L0381 INFO   | Dumping per-flow statistics
18:45:04 traffic_generation.run_traffic           L0383 INFO   | Stopping transmit on all remaining flows
18:45:10 snappi_api.info                          L1133 INFO   | Flows stop 5.671s
PASSED                                                                                                                                                                                                       [ 45%]
snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py::test_pfc_pause_single_lossless_prio_reboot[warm] 
-------------------------------------------------------------------------------------------------- live log setup --------------------------------------------------------------------------------------------------
18:45:23 __init__.set_default                     L0053 INFO   | Completeness level not set during test execution. Setting to default level: CompletenessLevel.basic
18:45:23 __init__.check_test_completeness         L0152 INFO   | Test has no defined levels. Continue without test completeness checks
18:45:23 __init__.loganalyzer                     L0051 INFO   | Log analyzer is disabled
18:45:23 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture snappi_testbed_config setup starts --------------------
18:45:24 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture snappi_testbed_config setup ends --------------------
-------------------------------------------------------------------------------------------------- live log call ---------------------------------------------------------------------------------------------------
18:45:25 test_pfc_pause_lossless_with_snappi.test L0247 INFO   | Issuing a warm reboot on the dut sonic-s6100-dut1
18:45:25 reboot.wait_for_shutdown                 L0143 INFO   | waiting for ssh to drop on sonic-s6100-dut1
18:45:25 reboot.execute_reboot_command            L0183 INFO   | rebooting sonic-s6100-dut1 with command "warm-reboot"
18:46:24 reboot.wait_for_startup                  L0164 INFO   | waiting for ssh to startup on sonic-s6100-dut1
18:46:40 reboot.wait_for_startup                  L0175 INFO   | ssh has started up on sonic-s6100-dut1
18:46:40 reboot.reboot                            L0256 INFO   | waiting for switch sonic-s6100-dut1 to initialize
18:50:09 processes_utils.wait_critical_processes  L0070 INFO   | Wait until all critical processes are healthy in 300 sec
18:50:09 processes_utils._all_critical_processes_ L0039 INFO   | Check critical processes status
18:50:18 reboot.reboot                            L0281 INFO   | warm reboot finished on sonic-s6100-dut1
18:50:19 reboot.reboot                            L0284 INFO   | DUT sonic-s6100-dut1 up since 2024-05-20 17:29:25.810000
18:50:19 test_pfc_pause_lossless_with_snappi.test L0250 INFO   | Wait until the system is stable
18:50:19 processes_utils.wait_critical_processes  L0070 INFO   | Wait until all critical processes are healthy in 300 sec
18:50:19 processes_utils._all_critical_processes_ L0039 INFO   | Check critical processes status
18:50:38 snappi_api.info                          L1133 INFO   | Config validation 0.022s
18:50:41 snappi_api.info                          L1133 INFO   | Ports configuration 0.588s
18:50:41 snappi_api.info                          L1133 INFO   | Captures configuration 0.343s
18:50:52 snappi_api.info                          L1133 INFO   | Location hosts ready [10.36.78.53] 2.212s
18:50:52 snappi_api.info                          L1133 INFO   | Speed change not require due to redundant Layer1 config
18:50:52 snappi_api.info                          L1133 INFO   | Aggregation mode speed change 0.011s
18:50:52 snappi_api.info                          L1133 INFO   | Location configuration 11.534s
18:51:09 snappi_api.info                          L1133 INFO   | Layer1 configuration 16.968s
18:51:10 snappi_api.info                          L1133 INFO   | Lag Configuration 0.157s
18:51:11 snappi_api.info                          L1133 INFO   | Convert device config : 1.321s
18:51:11 snappi_api.info                          L1133 INFO   | Create IxNetwork device config : 0.000s
18:51:12 snappi_api.info                          L1133 INFO   | Push IxNetwork device config : 0.623s
18:51:12 snappi_api.info                          L1133 INFO   | Devices configuration 2.127s
18:51:25 snappi_api.info                          L1133 INFO   | Flows configuration 12.842s
18:51:31 snappi_api.info                          L1133 INFO   | Start interfaces 6.147s
18:51:32 snappi_api.info                          L1133 INFO   | IxNet - The Traffic Item was modified. Please perform a Traffic Generate to update the associated traffic Flow Groups
18:51:32 traffic_generation.run_traffic           L0301 INFO   | Wait for Arp to Resolve ...
18:51:36 traffic_generation.run_traffic           L0318 INFO   | Starting transmit on all flows ...
18:51:39 snappi_api.info                          L1133 INFO   | Flows generate/apply 2.084s
18:51:49 snappi_api.info                          L1133 INFO   | Flows clear statistics 10.329s
18:51:49 snappi_api.info                          L1133 INFO   | Captures start 0.000s
18:51:53 snappi_api.info                          L1133 INFO   | Flows start 3.034s
18:51:54 traffic_generation.run_traffic           L0325 INFO   | Polling DUT for traffic statistics for 43 seconds ...
18:53:19 traffic_generation.run_traffic           L0343 INFO   | DUT polling complete
18:53:19 traffic_generation.run_traffic           L0351 INFO   | Checking if all flows have stopped. Attempt #1
18:53:22 traffic_generation.run_traffic           L0358 INFO   | All test and background traffic flows stopped
18:53:24 traffic_generation.run_traffic           L0381 INFO   | Dumping per-flow statistics
18:53:27 traffic_generation.run_traffic           L0383 INFO   | Stopping transmit on all remaining flows
18:53:33 snappi_api.info                          L1133 INFO   | Flows stop 5.502s
PASSED                                                                                                                                                                                                       [ 54%]
snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py::test_pfc_pause_single_lossless_prio_reboot[cold] 
-------------------------------------------------------------------------------------------------- live log setup --------------------------------------------------------------------------------------------------
18:53:41 __init__.set_default                     L0053 INFO   | Completeness level not set during test execution. Setting to default level: CompletenessLevel.basic
18:53:41 __init__.check_test_completeness         L0152 INFO   | Test has no defined levels. Continue without test completeness checks
18:53:41 __init__.loganalyzer                     L0051 INFO   | Log analyzer is disabled
18:53:41 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture snappi_testbed_config setup starts --------------------
18:53:42 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture snappi_testbed_config setup ends --------------------
-------------------------------------------------------------------------------------------------- live log call ---------------------------------------------------------------------------------------------------
18:53:42 test_pfc_pause_lossless_with_snappi.test L0247 INFO   | Issuing a cold reboot on the dut sonic-s6100-dut1
18:53:43 reboot.wait_for_shutdown                 L0143 INFO   | waiting for ssh to drop on sonic-s6100-dut1
18:53:43 reboot.execute_reboot_command            L0183 INFO   | rebooting sonic-s6100-dut1 with command "reboot"
18:54:04 reboot.wait_for_startup                  L0164 INFO   | waiting for ssh to startup on sonic-s6100-dut1
18:54:46 reboot.wait_for_startup                  L0175 INFO   | ssh has started up on sonic-s6100-dut1
18:54:46 reboot.reboot                            L0256 INFO   | waiting for switch sonic-s6100-dut1 to initialize
18:57:54 processes_utils.wait_critical_processes  L0070 INFO   | Wait until all critical processes are healthy in 300 sec
18:57:54 processes_utils._all_critical_processes_ L0039 INFO   | Check critical processes status
18:58:24 processes_utils._all_critical_processes_ L0039 INFO   | Check critical processes status
18:58:32 reboot.reboot                            L0281 INFO   | cold reboot finished on sonic-s6100-dut1
18:58:34 reboot.reboot                            L0284 INFO   | DUT sonic-s6100-dut1 up since 2024-05-20 17:37:27.170000
18:58:34 test_pfc_pause_lossless_with_snappi.test L0250 INFO   | Wait until the system is stable
18:58:34 processes_utils.wait_critical_processes  L0070 INFO   | Wait until all critical processes are healthy in 300 sec
18:58:34 processes_utils._all_critical_processes_ L0039 INFO   | Check critical processes status
18:58:54 snappi_api.info                          L1133 INFO   | Config validation 0.021s
18:58:56 snappi_api.info                          L1133 INFO   | Ports configuration 0.544s
18:58:56 snappi_api.info                          L1133 INFO   | Captures configuration 0.361s
18:59:08 snappi_api.info                          L1133 INFO   | Location hosts ready [10.36.78.53] 2.188s
18:59:08 snappi_api.info                          L1133 INFO   | Speed change not require due to redundant Layer1 config
18:59:08 snappi_api.info                          L1133 INFO   | Aggregation mode speed change 0.008s
18:59:08 snappi_api.info                          L1133 INFO   | Location configuration 11.371s
18:59:24 snappi_api.info                          L1133 INFO   | Layer1 configuration 16.601s
18:59:25 snappi_api.info                          L1133 INFO   | Lag Configuration 0.161s
18:59:26 snappi_api.info                          L1133 INFO   | Convert device config : 1.322s
18:59:26 snappi_api.info                          L1133 INFO   | Create IxNetwork device config : 0.000s
18:59:27 snappi_api.info                          L1133 INFO   | Push IxNetwork device config : 0.685s
18:59:27 snappi_api.info                          L1133 INFO   | Devices configuration 2.161s
18:59:40 snappi_api.info                          L1133 INFO   | Flows configuration 12.960s
18:59:47 snappi_api.info                          L1133 INFO   | Start interfaces 6.649s
18:59:47 snappi_api.info                          L1133 INFO   | IxNet - The Traffic Item was modified. Please perform a Traffic Generate to update the associated traffic Flow Groups
18:59:47 traffic_generation.run_traffic           L0301 INFO   | Wait for Arp to Resolve ...
18:59:51 traffic_generation.run_traffic           L0318 INFO   | Starting transmit on all flows ...
18:59:55 snappi_api.info                          L1133 INFO   | Flows generate/apply 2.128s
19:00:07 snappi_api.info                          L1133 INFO   | Flows clear statistics 12.348s
19:00:07 snappi_api.info                          L1133 INFO   | Captures start 0.000s
19:00:10 snappi_api.info                          L1133 INFO   | Flows start 2.750s
19:00:11 traffic_generation.run_traffic           L0325 INFO   | Polling DUT for traffic statistics for 47 seconds ...
19:01:48 traffic_generation.run_traffic           L0343 INFO   | DUT polling complete
19:01:48 traffic_generation.run_traffic           L0351 INFO   | Checking if all flows have stopped. Attempt #1
19:01:51 traffic_generation.run_traffic           L0358 INFO   | All test and background traffic flows stopped
19:01:53 traffic_generation.run_traffic           L0381 INFO   | Dumping per-flow statistics
19:01:56 traffic_generation.run_traffic           L0383 INFO   | Stopping transmit on all remaining flows
19:02:02 snappi_api.info                          L1133 INFO   | Flows stop 5.270s
PASSED                                                                                                                                                                                                       [ 63%]
snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py::test_pfc_pause_single_lossless_prio_reboot[fast] 
-------------------------------------------------------------------------------------------------- live log setup --------------------------------------------------------------------------------------------------
19:02:10 __init__.set_default                     L0053 INFO   | Completeness level not set during test execution. Setting to default level: CompletenessLevel.basic
19:02:10 __init__.check_test_completeness         L0152 INFO   | Test has no defined levels. Continue without test completeness checks
19:02:10 __init__.loganalyzer                     L0051 INFO   | Log analyzer is disabled
19:02:10 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture snappi_testbed_config setup starts --------------------
19:02:10 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture snappi_testbed_config setup ends --------------------
-------------------------------------------------------------------------------------------------- live log call ---------------------------------------------------------------------------------------------------
19:02:11 test_pfc_pause_lossless_with_snappi.test L0247 INFO   | Issuing a fast reboot on the dut sonic-s6100-dut1
19:02:12 reboot.wait_for_shutdown                 L0143 INFO   | waiting for ssh to drop on sonic-s6100-dut1
19:02:12 reboot.execute_reboot_command            L0183 INFO   | rebooting sonic-s6100-dut1 with command "fast-reboot"
19:03:10 reboot.wait_for_startup                  L0164 INFO   | waiting for ssh to startup on sonic-s6100-dut1
19:03:26 reboot.wait_for_startup                  L0175 INFO   | ssh has started up on sonic-s6100-dut1
19:03:26 reboot.reboot                            L0256 INFO   | waiting for switch sonic-s6100-dut1 to initialize
19:06:55 processes_utils.wait_critical_processes  L0070 INFO   | Wait until all critical processes are healthy in 300 sec
19:06:55 processes_utils._all_critical_processes_ L0039 INFO   | Check critical processes status
19:07:03 reboot.reboot                            L0281 INFO   | fast reboot finished on sonic-s6100-dut1
19:07:04 reboot.reboot                            L0284 INFO   | DUT sonic-s6100-dut1 up since 2024-05-20 17:46:13.100000
19:07:05 test_pfc_pause_lossless_with_snappi.test L0250 INFO   | Wait until the system is stable
19:07:05 processes_utils.wait_critical_processes  L0070 INFO   | Wait until all critical processes are healthy in 300 sec
19:07:05 processes_utils._all_critical_processes_ L0039 INFO   | Check critical processes status
19:07:24 snappi_api.info                          L1133 INFO   | Config validation 0.023s
19:07:27 snappi_api.info                          L1133 INFO   | Ports configuration 0.528s
19:07:27 snappi_api.info                          L1133 INFO   | Captures configuration 0.373s
19:07:38 snappi_api.info                          L1133 INFO   | Location hosts ready [10.36.78.53] 2.178s
19:07:38 snappi_api.info                          L1133 INFO   | Speed change not require due to redundant Layer1 config
19:07:38 snappi_api.info                          L1133 INFO   | Aggregation mode speed change 0.010s
19:07:39 snappi_api.info                          L1133 INFO   | Location configuration 11.473s
19:07:59 snappi_api.info                          L1133 INFO   | Layer1 configuration 20.097s
19:07:59 snappi_api.info                          L1133 INFO   | Lag Configuration 0.161s
19:08:01 snappi_api.info                          L1133 INFO   | Convert device config : 1.492s
19:08:01 snappi_api.info                          L1133 INFO   | Create IxNetwork device config : 0.000s
19:08:01 snappi_api.info                          L1133 INFO   | Push IxNetwork device config : 0.558s
19:08:01 snappi_api.info                          L1133 INFO   | Devices configuration 2.207s
19:08:14 snappi_api.info                          L1133 INFO   | Flows configuration 12.876s
19:08:21 snappi_api.info                          L1133 INFO   | Start interfaces 6.984s
19:08:22 snappi_api.info                          L1133 INFO   | IxNet - The Traffic Item was modified. Please perform a Traffic Generate to update the associated traffic Flow Groups
19:08:22 traffic_generation.run_traffic           L0301 INFO   | Wait for Arp to Resolve ...
19:08:26 traffic_generation.run_traffic           L0318 INFO   | Starting transmit on all flows ...
19:08:29 snappi_api.info                          L1133 INFO   | Flows generate/apply 2.154s
19:08:42 snappi_api.info                          L1133 INFO   | Flows clear statistics 12.285s
19:08:42 snappi_api.info                          L1133 INFO   | Captures start 0.000s
19:08:46 snappi_api.info                          L1133 INFO   | Flows start 3.865s
19:08:46 traffic_generation.run_traffic           L0325 INFO   | Polling DUT for traffic statistics for 51 seconds ...
19:10:23 traffic_generation.run_traffic           L0343 INFO   | DUT polling complete
19:10:23 traffic_generation.run_traffic           L0351 INFO   | Checking if all flows have stopped. Attempt #1
19:10:26 traffic_generation.run_traffic           L0358 INFO   | All test and background traffic flows stopped
19:10:28 traffic_generation.run_traffic           L0381 INFO   | Dumping per-flow statistics
19:10:31 traffic_generation.run_traffic           L0383 INFO   | Stopping transmit on all remaining flows
19:10:38 snappi_api.info                          L1133 INFO   | Flows stop 6.679s
PASSED                                                                                                                                                                                                       [ 72%]
snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py::test_pfc_pause_multi_lossless_prio_reboot[warm] 
-------------------------------------------------------------------------------------------------- live log setup --------------------------------------------------------------------------------------------------
19:10:45 __init__.set_default                     L0053 INFO   | Completeness level not set during test execution. Setting to default level: CompletenessLevel.basic
19:10:45 __init__.check_test_completeness         L0152 INFO   | Test has no defined levels. Continue without test completeness checks
19:10:45 __init__.loganalyzer                     L0051 INFO   | Log analyzer is disabled
19:10:45 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture snappi_testbed_config setup starts --------------------
19:10:46 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture snappi_testbed_config setup ends --------------------
-------------------------------------------------------------------------------------------------- live log call ---------------------------------------------------------------------------------------------------
19:10:47 test_pfc_pause_lossless_with_snappi.test L0318 INFO   | Issuing a warm reboot on the dut sonic-s6100-dut1
19:10:48 reboot.wait_for_shutdown                 L0143 INFO   | waiting for ssh to drop on sonic-s6100-dut1
19:10:48 reboot.execute_reboot_command            L0183 INFO   | rebooting sonic-s6100-dut1 with command "warm-reboot"
19:11:46 reboot.wait_for_startup                  L0164 INFO   | waiting for ssh to startup on sonic-s6100-dut1
19:12:03 reboot.wait_for_startup                  L0175 INFO   | ssh has started up on sonic-s6100-dut1
19:12:03 reboot.reboot                            L0256 INFO   | waiting for switch sonic-s6100-dut1 to initialize
19:15:32 processes_utils.wait_critical_processes  L0070 INFO   | Wait until all critical processes are healthy in 300 sec
19:15:32 processes_utils._all_critical_processes_ L0039 INFO   | Check critical processes status
19:15:41 reboot.reboot                            L0281 INFO   | warm reboot finished on sonic-s6100-dut1
19:15:42 reboot.reboot                            L0284 INFO   | DUT sonic-s6100-dut1 up since 2024-05-20 17:54:49.060000
19:15:43 test_pfc_pause_lossless_with_snappi.test L0321 INFO   | Wait until the system is stable
19:15:43 processes_utils.wait_critical_processes  L0070 INFO   | Wait until all critical processes are healthy in 300 sec
19:15:43 processes_utils._all_critical_processes_ L0039 INFO   | Check critical processes status
19:16:02 snappi_api.info                          L1133 INFO   | Config validation 0.029s
19:16:04 snappi_api.info                          L1133 INFO   | Ports configuration 0.557s
19:16:05 snappi_api.info                          L1133 INFO   | Captures configuration 0.378s
19:16:16 snappi_api.info                          L1133 INFO   | Location hosts ready [10.36.78.53] 2.182s
19:16:16 snappi_api.info                          L1133 INFO   | Speed change not require due to redundant Layer1 config
19:16:16 snappi_api.info                          L1133 INFO   | Aggregation mode speed change 0.009s
19:16:16 snappi_api.info                          L1133 INFO   | Location configuration 11.358s
19:16:35 snappi_api.info                          L1133 INFO   | Layer1 configuration 19.221s
19:16:36 snappi_api.info                          L1133 INFO   | Lag Configuration 0.152s
19:16:37 snappi_api.info                          L1133 INFO   | Convert device config : 1.565s
19:16:37 snappi_api.info                          L1133 INFO   | Create IxNetwork device config : 0.000s
19:16:38 snappi_api.info                          L1133 INFO   | Push IxNetwork device config : 0.530s
19:16:38 snappi_api.info                          L1133 INFO   | Devices configuration 2.249s
19:16:51 snappi_api.info                          L1133 INFO   | Flows configuration 12.682s
19:16:57 snappi_api.info                          L1133 INFO   | Start interfaces 5.609s
19:16:57 snappi_api.info                          L1133 INFO   | IxNet - The Traffic Item was modified. Please perform a Traffic Generate to update the associated traffic Flow Groups
19:16:57 traffic_generation.run_traffic           L0301 INFO   | Wait for Arp to Resolve ...
19:17:01 traffic_generation.run_traffic           L0318 INFO   | Starting transmit on all flows ...
19:17:04 snappi_api.info                          L1133 INFO   | Flows generate/apply 2.164s
19:17:17 snappi_api.info                          L1133 INFO   | Flows clear statistics 12.240s
19:17:17 snappi_api.info                          L1133 INFO   | Captures start 0.000s
19:17:20 snappi_api.info                          L1133 INFO   | Flows start 2.649s
19:17:20 traffic_generation.run_traffic           L0325 INFO   | Polling DUT for traffic statistics for 55 seconds ...
19:19:43 traffic_generation.run_traffic           L0343 INFO   | DUT polling complete
19:19:43 traffic_generation.run_traffic           L0351 INFO   | Checking if all flows have stopped. Attempt #1
19:19:46 traffic_generation.run_traffic           L0358 INFO   | All test and background traffic flows stopped
19:19:48 traffic_generation.run_traffic           L0381 INFO   | Dumping per-flow statistics
19:19:51 traffic_generation.run_traffic           L0383 INFO   | Stopping transmit on all remaining flows
19:19:58 snappi_api.info                          L1133 INFO   | Flows stop 6.394s
PASSED                                                                                                                                                                                                       [ 81%]
snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py::test_pfc_pause_multi_lossless_prio_reboot[cold] 
-------------------------------------------------------------------------------------------------- live log setup --------------------------------------------------------------------------------------------------
19:20:11 __init__.set_default                     L0053 INFO   | Completeness level not set during test execution. Setting to default level: CompletenessLevel.basic
19:20:11 __init__.check_test_completeness         L0152 INFO   | Test has no defined levels. Continue without test completeness checks
19:20:11 __init__.loganalyzer                     L0051 INFO   | Log analyzer is disabled
19:20:11 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture snappi_testbed_config setup starts --------------------
19:20:12 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture snappi_testbed_config setup ends --------------------
-------------------------------------------------------------------------------------------------- live log call ---------------------------------------------------------------------------------------------------
19:20:13 test_pfc_pause_lossless_with_snappi.test L0318 INFO   | Issuing a cold reboot on the dut sonic-s6100-dut1
19:20:13 reboot.wait_for_shutdown                 L0143 INFO   | waiting for ssh to drop on sonic-s6100-dut1
19:20:13 reboot.execute_reboot_command            L0183 INFO   | rebooting sonic-s6100-dut1 with command "reboot"
19:20:35 reboot.wait_for_startup                  L0164 INFO   | waiting for ssh to startup on sonic-s6100-dut1
19:21:17 reboot.wait_for_startup                  L0175 INFO   | ssh has started up on sonic-s6100-dut1
19:21:17 reboot.reboot                            L0256 INFO   | waiting for switch sonic-s6100-dut1 to initialize
19:24:46 processes_utils.wait_critical_processes  L0070 INFO   | Wait until all critical processes are healthy in 300 sec
19:24:46 processes_utils._all_critical_processes_ L0039 INFO   | Check critical processes status
19:24:56 reboot.reboot                            L0281 INFO   | cold reboot finished on sonic-s6100-dut1
19:24:57 reboot.reboot                            L0284 INFO   | DUT sonic-s6100-dut1 up since 2024-05-20 18:03:56.490000
19:24:57 test_pfc_pause_lossless_with_snappi.test L0321 INFO   | Wait until the system is stable
19:24:57 processes_utils.wait_critical_processes  L0070 INFO   | Wait until all critical processes are healthy in 300 sec
19:24:57 processes_utils._all_critical_processes_ L0039 INFO   | Check critical processes status
19:25:17 snappi_api.info                          L1133 INFO   | Config validation 0.022s
19:25:19 snappi_api.info                          L1133 INFO   | Ports configuration 0.535s
19:25:19 snappi_api.info                          L1133 INFO   | Captures configuration 0.336s
19:25:30 snappi_api.info                          L1133 INFO   | Location hosts ready [10.36.78.53] 2.173s
19:25:30 snappi_api.info                          L1133 INFO   | Speed change not require due to redundant Layer1 config
19:25:30 snappi_api.info                          L1133 INFO   | Aggregation mode speed change 0.008s
19:25:30 snappi_api.info                          L1133 INFO   | Location configuration 11.354s
19:25:46 snappi_api.info                          L1133 INFO   | Layer1 configuration 16.067s
19:25:47 snappi_api.info                          L1133 INFO   | Lag Configuration 0.211s
19:25:48 snappi_api.info                          L1133 INFO   | Convert device config : 1.362s
19:25:48 snappi_api.info                          L1133 INFO   | Create IxNetwork device config : 0.000s
19:25:49 snappi_api.info                          L1133 INFO   | Push IxNetwork device config : 0.554s
19:25:49 snappi_api.info                          L1133 INFO   | Devices configuration 2.070s
19:26:02 snappi_api.info                          L1133 INFO   | Flows configuration 12.779s
19:26:07 snappi_api.info                          L1133 INFO   | Start interfaces 4.860s
19:26:07 snappi_api.info                          L1133 INFO   | IxNet - The Traffic Item was modified. Please perform a Traffic Generate to update the associated traffic Flow Groups
19:26:07 traffic_generation.run_traffic           L0301 INFO   | Wait for Arp to Resolve ...
19:26:11 traffic_generation.run_traffic           L0318 INFO   | Starting transmit on all flows ...
19:26:14 snappi_api.info                          L1133 INFO   | Flows generate/apply 1.249s
19:26:26 snappi_api.info                          L1133 INFO   | Flows clear statistics 12.435s
19:26:26 snappi_api.info                          L1133 INFO   | Captures start 0.000s
19:26:30 snappi_api.info                          L1133 INFO   | Flows start 2.753s
19:26:30 traffic_generation.run_traffic           L0325 INFO   | Polling DUT for traffic statistics for 59 seconds ...
19:29:04 traffic_generation.run_traffic           L0343 INFO   | DUT polling complete
19:29:04 traffic_generation.run_traffic           L0351 INFO   | Checking if all flows have stopped. Attempt #1
19:29:07 traffic_generation.run_traffic           L0358 INFO   | All test and background traffic flows stopped
19:29:09 traffic_generation.run_traffic           L0381 INFO   | Dumping per-flow statistics
19:29:12 traffic_generation.run_traffic           L0383 INFO   | Stopping transmit on all remaining flows
19:29:19 snappi_api.info                          L1133 INFO   | Flows stop 6.754s
PASSED                                                                                                                                                                                                       [ 90%]
snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py::test_pfc_pause_multi_lossless_prio_reboot[fast] 
-------------------------------------------------------------------------------------------------- live log setup --------------------------------------------------------------------------------------------------
19:29:33 __init__.set_default                     L0053 INFO   | Completeness level not set during test execution. Setting to default level: CompletenessLevel.basic
19:29:33 __init__.check_test_completeness         L0152 INFO   | Test has no defined levels. Continue without test completeness checks
19:29:33 __init__.loganalyzer                     L0051 INFO   | Log analyzer is disabled
19:29:33 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture snappi_testbed_config setup starts --------------------
19:29:33 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture snappi_testbed_config setup ends --------------------
-------------------------------------------------------------------------------------------------- live log call ---------------------------------------------------------------------------------------------------
19:29:34 test_pfc_pause_lossless_with_snappi.test L0318 INFO   | Issuing a fast reboot on the dut sonic-s6100-dut1
19:29:35 reboot.wait_for_shutdown                 L0143 INFO   | waiting for ssh to drop on sonic-s6100-dut1
19:29:35 reboot.execute_reboot_command            L0183 INFO   | rebooting sonic-s6100-dut1 with command "fast-reboot"
19:30:33 reboot.wait_for_startup                  L0164 INFO   | waiting for ssh to startup on sonic-s6100-dut1
19:30:53 reboot.wait_for_startup                  L0175 INFO   | ssh has started up on sonic-s6100-dut1
19:30:53 reboot.reboot                            L0256 INFO   | waiting for switch sonic-s6100-dut1 to initialize
19:34:21 processes_utils.wait_critical_processes  L0070 INFO   | Wait until all critical processes are healthy in 300 sec
19:34:21 processes_utils._all_critical_processes_ L0039 INFO   | Check critical processes status
19:34:30 reboot.reboot                            L0281 INFO   | fast reboot finished on sonic-s6100-dut1
19:34:31 reboot.reboot                            L0284 INFO   | DUT sonic-s6100-dut1 up since 2024-05-20 18:13:38
19:34:32 test_pfc_pause_lossless_with_snappi.test L0321 INFO   | Wait until the system is stable
19:34:32 processes_utils.wait_critical_processes  L0070 INFO   | Wait until all critical processes are healthy in 300 sec
19:34:32 processes_utils._all_critical_processes_ L0039 INFO   | Check critical processes status
19:34:51 snappi_api.info                          L1133 INFO   | Config validation 0.022s
19:34:53 snappi_api.info                          L1133 INFO   | Ports configuration 0.525s
19:34:53 snappi_api.info                          L1133 INFO   | Captures configuration 0.347s
19:35:05 snappi_api.info                          L1133 INFO   | Location hosts ready [10.36.78.53] 2.184s
19:35:05 snappi_api.info                          L1133 INFO   | Speed change not require due to redundant Layer1 config
19:35:05 snappi_api.info                          L1133 INFO   | Aggregation mode speed change 0.011s
19:35:05 snappi_api.info                          L1133 INFO   | Location configuration 11.759s
19:35:23 snappi_api.info                          L1133 INFO   | Layer1 configuration 17.739s
19:35:23 snappi_api.info                          L1133 INFO   | Lag Configuration 0.160s
19:35:24 snappi_api.info                          L1133 INFO   | Convert device config : 1.293s
19:35:24 snappi_api.info                          L1133 INFO   | Create IxNetwork device config : 0.000s
19:35:25 snappi_api.info                          L1133 INFO   | Push IxNetwork device config : 0.560s
19:35:25 snappi_api.info                          L1133 INFO   | Devices configuration 2.010s
19:35:38 snappi_api.info                          L1133 INFO   | Flows configuration 12.948s
19:35:46 snappi_api.info                          L1133 INFO   | Start interfaces 7.537s
19:35:46 snappi_api.info                          L1133 INFO   | IxNet - The Traffic Item was modified. Please perform a Traffic Generate to update the associated traffic Flow Groups
19:35:46 traffic_generation.run_traffic           L0301 INFO   | Wait for Arp to Resolve ...
19:35:51 traffic_generation.run_traffic           L0318 INFO   | Starting transmit on all flows ...
19:35:54 snappi_api.info                          L1133 INFO   | Flows generate/apply 1.954s
19:36:06 snappi_api.info                          L1133 INFO   | Flows clear statistics 12.279s
19:36:06 snappi_api.info                          L1133 INFO   | Captures start 0.000s
19:36:11 snappi_api.info                          L1133 INFO   | Flows start 3.615s
19:36:11 traffic_generation.run_traffic           L0325 INFO   | Polling DUT for traffic statistics for 63 seconds ...
19:38:44 traffic_generation.run_traffic           L0343 INFO   | DUT polling complete
19:38:44 traffic_generation.run_traffic           L0351 INFO   | Checking if all flows have stopped. Attempt #1
19:38:47 traffic_generation.run_traffic           L0358 INFO   | All test and background traffic flows stopped
19:38:49 traffic_generation.run_traffic           L0381 INFO   | Dumping per-flow statistics
19:38:52 traffic_generation.run_traffic           L0383 INFO   | Stopping transmit on all remaining flows
19:38:58 snappi_api.info                          L1133 INFO   | Flows stop 5.762s
PASSED                                                                                                                                                                                                       [100%]
------------------------------------------------------------------------------------------------ live log teardown -------------------------------------------------------------------------------------------------
19:39:11 __init__._fixture_generator_decorator    L0093 INFO   | -------------------- fixture snappi_api teardown starts --------------------
19:39:30 __init__._fixture_generator_decorator    L0102 INFO   | -------------------- fixture snappi_api teardown ends --------------------
19:39:30 __init__._fixture_generator_decorator    L0093 INFO   | -------------------- fixture start_pfcwd_after_test teardown starts --------------------
19:39:31 __init__._fixture_generator_decorator    L0102 INFO   | -------------------- fixture start_pfcwd_after_test teardown ends --------------------
19:39:31 __init__._fixture_generator_decorator    L0093 INFO   | -------------------- fixture rand_lossy_prio teardown starts --------------------
19:39:31 __init__._fixture_generator_decorator    L0102 INFO   | -------------------- fixture rand_lossy_prio teardown ends --------------------
19:39:31 __init__._fixture_generator_decorator    L0093 INFO   | -------------------- fixture rand_lossless_prio teardown starts --------------------
19:39:31 __init__._fixture_generator_decorator    L0102 INFO   | -------------------- fixture rand_lossless_prio teardown ends --------------------
19:39:31 __init__._fixture_generator_decorator    L0093 INFO   | -------------------- fixture enable_packet_aging_after_test teardown starts --------------------
19:39:31 __init__._fixture_generator_decorator    L0102 INFO   | -------------------- fixture enable_packet_aging_after_test teardown ends --------------------
19:39:33 conftest.core_dump_and_config_check      L2098 INFO   | Dumping Disk and Memory Space informataion after test on sonic-s6100-dut1
19:39:34 conftest.core_dump_and_config_check      L2102 INFO   | Collecting core dumps after test on sonic-s6100-dut1
19:39:35 conftest.core_dump_and_config_check      L2119 INFO   | Collecting running config after test on sonic-s6100-dut1
19:40:05 conftest.core_dump_and_config_check      L2258 INFO   | sonic-s6100-dut1: sudo config reload config_db_clean.json -f -y
19:40:05 conftest.core_dump_and_config_check      L2259 INFO   | Core dump and config check passed for test_pfc_pause_lossless_with_snappi.py


================================================================================================= warnings summary =================================================================================================
../../../../usr/local/lib/python3.8/dist-packages/_pytest/config/__init__.py:755
  /usr/local/lib/python3.8/dist-packages/_pytest/config/__init__.py:755: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: tests.common.plugins.loganalyzer
    self.import_plugin(import_spec)

../../../../usr/local/lib/python3.8/dist-packages/_pytest/config/__init__.py:755
  /usr/local/lib/python3.8/dist-packages/_pytest/config/__init__.py:755: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: tests.common.plugins.sanity_check
    self.import_plugin(import_spec)

../../../../usr/local/lib/python3.8/dist-packages/_pytest/config/__init__.py:755
  /usr/local/lib/python3.8/dist-packages/_pytest/config/__init__.py:755: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: tests.common.plugins.test_completeness
    self.import_plugin(import_spec)

../../../../usr/local/lib/python3.8/dist-packages/_pytest/config/__init__.py:755
  /usr/local/lib/python3.8/dist-packages/_pytest/config/__init__.py:755: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: tests.common.dualtor
    self.import_plugin(import_spec)

../../../../usr/local/lib/python3.8/dist-packages/scapy/layers/ipsec.py:471
  /usr/local/lib/python3.8/dist-packages/scapy/layers/ipsec.py:471: CryptographyDeprecationWarning: Blowfish has been deprecated
    cipher=algorithms.Blowfish,

../../../../usr/local/lib/python3.8/dist-packages/scapy/layers/ipsec.py:485
  /usr/local/lib/python3.8/dist-packages/scapy/layers/ipsec.py:485: CryptographyDeprecationWarning: CAST5 has been deprecated
    cipher=algorithms.CAST5,

../../../../usr/local/lib/python3.8/dist-packages/paramiko/transport.py:236
  /usr/local/lib/python3.8/dist-packages/paramiko/transport.py:236: CryptographyDeprecationWarning: Blowfish has been deprecated
    "class": algorithms.Blowfish,

snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py: 14 warnings
  /usr/local/lib/python3.8/dist-packages/pytest_ansible/module_dispatcher/v213.py:100: UserWarning: provided hosts list is empty, only localhost is available
    warnings.warn("provided hosts list is empty, only localhost is available")

snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py::test_pfc_pause_single_lossless_prio[sonic-s6100-dut1|3]
  /var/AzDevOps/.local/lib/python3.8/site-packages/snappi_ixnetwork/device/utils.py:2: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working
    from collections import namedtuple, Mapping

snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py::test_pfc_pause_single_lossless_prio[sonic-s6100-dut1|3]
snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py::test_pfc_pause_single_lossless_prio[sonic-s6100-dut1|3]
  /usr/local/lib/python3.8/dist-packages/ixnetwork_restpy/testplatform/sessions/sessions.py:59: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    elif LooseVersion(build_number) < LooseVersion('8.52'):

snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py: 10 warnings
  /usr/lib/python3/dist-packages/urllib3/connectionpool.py:999: InsecureRequestWarning: Unverified HTTPS request is being made to host '10.36.78.2'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
---------------------------------------------------------------------------------------------- live log sessionfinish ----------------------------------------------------------------------------------------------
19:40:05 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs
=================================================================================== 11 passed, 34 warnings in 4408.45s (1:13:28) ===================================================================================
INFO:root:Can not get Allure report URL. Please check logs