### PR TITLE
[Snappi]: Adding FEC Error Insertion Test Script

### DIFF
--- a/tests/snappi_tests/dataplane/test_fec_error_injection.py
+++ b/tests/snappi_tests/dataplane/test_fec_error_injection.py
@@ -1,41 +1,51 @@
-from tests.snappi_tests.dataplane.imports import *
-from tests.common.snappi_tests.traffic_generation import setup_base_traffic_config
-from tests.common.snappi_tests.common_helpers import traffic_flow_mode
-from tests.common.snappi_tests.snappi_helpers import wait_for_arp, fetch_snappi_flow_metrics
+from tests.snappi_tests.dataplane.imports import *        # noqa: F401
+from tests.common.snappi_tests.traffic_generation import setup_base_traffic_config     # noqa: F401
+from tests.common.snappi_tests.common_helpers import traffic_flow_mode      # noqa: F401
+from tests.common.snappi_tests.snappi_helpers import wait_for_arp, fetch_snappi_flow_metrics      # noqa: F401
 logger = logging.getLogger(__name__)
 pytestmark = [pytest.mark.topology('tgen')]
 
-ErrorTypes = [  'maxConsecutiveUncorrectableWithoutLossOfLink',
-                'codeWords',
-                'minConsecutiveUncorrectableWithLossOfLink',
-                'laneMarkers'
-            ]
+ErrorTypes = ['codeWords',
+              'laneMarkers',
+              'minConsecutiveUncorrectableWithLossOfLink',
+              'maxConsecutiveUncorrectableWithoutLossOfLink'
+              ]
 
-@pytest.mark.parametrize('error_type', ErrorTypes)
-def test_fec_error_injection(snappi_api,                   # noqa F811
-                             snappi_testbed_config,        # noqa F811
-                             conn_graph_facts,             # noqa F811
-                             fanout_graph_facts,           # noqa F811
-                             duthosts,
-                             error_type,
-                             rand_one_dut_portname_oper_up,
-                             rand_one_dut_hostname):               # noqa F811
 
+def get_ti_stats(ixnet):
+    tiStatistics = StatViewAssistant(ixnet, 'Traffic Item Statistics')
+    tdf = pd.DataFrame(tiStatistics.Rows.RawData, columns=tiStatistics.ColumnHeaders)
+    selected_columns = ['Tx Frames', 'Rx Frames', 'Frames Delta', 'Loss %', 'Tx Frame Rate', 'Rx Frame Rate']
+    tmp = tdf[selected_columns]
+    return tmp
+
+
+@pytest.fixture(scope="function", autouse=True)
+def setup_config(snappi_api,
+                 snappi_testbed_config,
+                 conn_graph_facts,
+                 fanout_graph_facts,
+                 duthosts,
+                 rand_one_dut_portname_oper_up,
+                 rand_one_dut_hostname):
+    """
+    Fixture to initialize resources for the test.
+    """
     dut_hostname, dut_port = rand_one_dut_portname_oper_up.split('|')
     testbed_config, port_config_list = snappi_testbed_config
     duthost = duthosts[rand_one_dut_hostname]
-    api=snappi_api
-    conn_data=conn_graph_facts
-    fanout_data=fanout_graph_facts
-    snappi_extra_params=None    
-     
+    api = snappi_api
+    conn_data = conn_graph_facts
+    fanout_data = fanout_graph_facts
+    snappi_extra_params = None    
+
     if snappi_extra_params is None:
         snappi_extra_params = SnappiTestParams()
     port_id = get_dut_port_id(duthost.hostname,
-                            dut_port,
-                            conn_data,
-                            fanout_data)
-    
+                              dut_port,
+                              conn_data,
+                              fanout_data)
+
     pytest_assert(port_id is not None,
                 'Fail to get ID for port {}'.format(dut_port))
     snappi_extra_params.base_flow_config = setup_base_traffic_config(testbed_config=testbed_config,
@@ -49,12 +59,31 @@ def test_fec_error_injection(snappi_api,                   # noqa F811
     test_flow.metrics.loss = True
     test_flow.size.fixed = 64
     test_flow.rate.percentage = 10
-    
-    api.set_config(testbed_config) 
+    api.set_config(testbed_config)
+    test_platform = TestPlatform(snappi_api._address)
+    test_platform.Authenticate(snappi_api._username, snappi_api._password)
+    id = test_platform.Sessions.find()[-1].Id
+    session_assistant = SessionAssistant(IpAddress=snappi_api._address,
+                                         RestPort=snappi_api._port,
+                                         SessionId=id,
+                                         UserName=snappi_api._username,
+                                         Password=snappi_api._password)
+    yield api, port_config_list, session_assistant
+
+
+@pytest.mark.parametrize('error_type', ErrorTypes)
+def test_fec_error_injection(duthosts,
+                             error_type,
+                             setup_config):
+    """
+    Test to check if packets get dropped on injecting fec errors
+    """
+    api, port_config_list, session_assistant = setup_config
+    ixnet = api._ixnetwork
     logger.info("Wait for Arp to Resolve ...")
     wait_for_arp(api, max_attempts=30, poll_interval_sec=2)
-    ixnet = api._ixnetwork
-    port1 = ixnet.Vport.find()[0]
+
+    port1 = ixnet.Vport.find()[port_config_list[0].id]
     logger.info('|----------------------------------------|')
     logger.info('| Setting FEC Error Type to : {} |'.format(error_type))
     logger.info('|----------------------------------------|')
@@ -68,25 +97,50 @@ def test_fec_error_injection(snappi_api,                   # noqa F811
     ts.traffic.flow_transmit.state = ts.traffic.flow_transmit.START
     api.set_control_state(ts)
     wait(10, "For traffic to start")
+    try:
+        logger.info('Starting FEC Error Insertion')
+        port1.StartFecErrorInsertion()
+        wait(15, "For error insertion to start")
+        logger.info('Dumping Traffic Item statistics :\n {}'.format(tabulate(get_ti_stats(ixnet), headers='keys', tablefmt='psql')))
+        if error_type == 'minConsecutiveUncorrectableWithLossOfLink' or error_type == 'codeWords' or error_type == 'laneMarkers':
+            pytest_assert(duthosts[0].links_status_down(port_config_list[0].peer_port) is True,
+                          "FAIL: Link is still up after injecting FEC Error")
+            logger.info('|----------------------------------------|')
+            logger.info("PASS: Link Went down after injecting FEC Error: {}".format(error_type))
+            logger.info('|----------------------------------------|')
+        elif error_type == 'maxConsecutiveUncorrectableWithoutLossOfLink':
+            pytest_assert(duthosts[0].links_status_down(port_config_list[0].peer_port) is False,
+                          "FAIL: Link went down after injecting FEC Error")
+            logger.info('|----------------------------------------|')
+            logger.info("PASS: Link didn't go down after injecting FEC Error: {}".format(error_type))
+            logger.info('|----------------------------------------|')
 
-    logger.info('Starting FEC Error Insertion')
-    port1.StartFecErrorInsertion()
-    wait(15, "For error insertion to start")
-    # TODO For maxConsecutiveUncorrectableWithoutLossOfLink check link state on DUT
-    flow_metrics = fetch_snappi_flow_metrics(api, ['IPv4 Traffic'])[0]
-    pytest_assert(flow_metrics.frames_tx > 0 and int(flow_metrics.loss) > 0,
-                "FAIL: Rx Port did not stop receiving packets after starting FEC Error Insertion")
-    logger.info(' .. PASSED : Rx Port stopped receiving packets after starting FEC Error Insertion')
-    logger.info('Stopping FEC Error Insertion')
-    port1.StopFecErrorInsertion()
-    wait(15, "For error insertion to stop")
-    ixnet.ClearStats()
-    flow_metrics = fetch_snappi_flow_metrics(api, ['IPv4 Traffic'])[0]
-    pytest_assert(int(flow_metrics.frames_rx_rate) > 0 and int(flow_metrics.loss) == 0,
-                "FAIL: Rx Port did not resume receiving packets after stopping FEC Error Insertion")
-    logger.info(' .. PASSED : Rx Port resumed receiving packets after stopping FEC Error Insertion')
-    logger.info('Stopping Traffic ...')
-    ts = api.control_state()
-    ts.traffic.flow_transmit.state = ts.traffic.flow_transmit.STOP
-    api.set_control_state(ts)
-    wait(10, "For traffic to stop")
+        flow_metrics = fetch_snappi_flow_metrics(api, ['IPv4 Traffic'])[0]
+        pytest_assert(flow_metrics.frames_tx > 0 and int(flow_metrics.loss) > 0,
+                    "FAIL: Rx Port did not stop receiving packets after starting FEC Error Insertion")
+        logger.info('PASS : Rx Port stopped receiving packets after starting FEC Error Insertion')
+        logger.info('Stopping FEC Error Insertion')
+        port1.StopFecErrorInsertion()
+        wait(15, "For error insertion to stop")
+        if error_type == 'minConsecutiveUncorrectableWithLossOfLink' or error_type == 'laneMarkers' or error_type == 'codeWords':
+            pytest_assert(duthosts[0].links_status_down(port_config_list[0].peer_port) is False,
+                          "FAIL: Link is still down after stopping FEC Error")
+            logger.info('|----------------------------------------|')
+            logger.info("PASS: Link is up after stopping FEC Error injection: {}".format(error_type))
+            logger.info('|----------------------------------------|')
+        ixnet.ClearStats()
+        wait(10, "For clear stats operation to complete")
+        logger.info('Dumping Traffic Item statistics :\n {}'.
+                    format(tabulate(get_ti_stats(ixnet), headers='keys', tablefmt='psql')))
+        flow_metrics = fetch_snappi_flow_metrics(api, ['IPv4 Traffic'])[0]
+        pytest_assert(int(flow_metrics.frames_rx_rate) > 0 and int(flow_metrics.loss) == 0,
+                      "FAIL: Rx Port did not resume receiving packets after stopping FEC Error Insertion")
+        logger.info('PASS : Rx Port resumed receiving packets after stopping FEC Error Insertion')
+        logger.info('Stopping Traffic ...')
+        ts = api.control_state()
+        ts.traffic.flow_transmit.state = ts.traffic.flow_transmit.STOP
+        api.set_control_state(ts)
+        wait(10, "For traffic to stop")
+    finally:
+        logger.info('....Finally Block')
+        port1.StopFecErrorInsertion()

--- a/tests/snappi_tests/dataplane/test_fec_error_injection.py
+++ b/tests/snappi_tests/dataplane/test_fec_error_injection.py
@@ -1,0 +1,96 @@
+from tests.snappi_tests.dataplane.imports import *
+from tests.common.snappi_tests.traffic_generation import setup_base_traffic_config
+from tests.common.snappi_tests.common_helpers import traffic_flow_mode
+from tests.common.snappi_tests.snappi_helpers import wait_for_arp, fetch_snappi_flow_metrics
+logger = logging.getLogger(__name__)
+pytestmark = [pytest.mark.topology('tgen')]
+
+ErrorTypes = [  'maxConsecutiveUncorrectableWithoutLossOfLink',
+                'codeWords',
+                'minConsecutiveUncorrectableWithLossOfLink',
+                'laneMarkers'
+            ]
+# ErrorTypes = [
+#                 'minConsecutiveUncorrectableWithLossOfLink'
+#             ]
+
+@pytest.mark.parametrize('error_type', ErrorTypes)
+def test_fec_error_injection(snappi_api,                   # noqa F811
+                             snappi_testbed_config,        # noqa F811
+                             conn_graph_facts,             # noqa F811
+                             fanout_graph_facts,           # noqa F811
+                             duthosts,
+                             error_type,
+                             rand_one_dut_portname_oper_up,
+                             rand_one_dut_hostname):               # noqa F811
+
+    dut_hostname, dut_port = rand_one_dut_portname_oper_up.split('|')
+    testbed_config, port_config_list = snappi_testbed_config
+    duthost = duthosts[rand_one_dut_hostname]
+    api=snappi_api
+    conn_data=conn_graph_facts
+    fanout_data=fanout_graph_facts
+    snappi_extra_params=None    
+     
+    if snappi_extra_params is None:
+        snappi_extra_params = SnappiTestParams()
+    port_id = get_dut_port_id(duthost.hostname,
+                            dut_port,
+                            conn_data,
+                            fanout_data)
+    
+    pytest_assert(port_id is not None,
+                'Fail to get ID for port {}'.format(dut_port))
+    snappi_extra_params.base_flow_config = setup_base_traffic_config(testbed_config=testbed_config,
+                                                                     port_config_list=port_config_list,
+                                                                     port_id=port_id)
+    base_flow = snappi_extra_params.base_flow_config
+    test_flow = testbed_config.flows.flow(name='IPv4 Traffic')[-1]
+    test_flow.tx_rx.device.tx_names = [testbed_config.devices[0].name]
+    test_flow.tx_rx.device.rx_names = [testbed_config.devices[1].name]
+    test_flow.metrics.enable = True
+    test_flow.metrics.loss = True
+    test_flow.size.fixed = 64
+    test_flow.rate.percentage = 10
+    
+    api.set_config(testbed_config) 
+    logger.info("Wait for Arp to Resolve ...")
+    wait_for_arp(api, max_attempts=30, poll_interval_sec=2)
+    ixnet = api._ixnetwork
+    port1 = ixnet.Vport.find()[0]
+    logger.info('|----------------------------------------|')
+    logger.info('| Setting FEC Error Type to : {} |'.format(error_type))
+    logger.info('|----------------------------------------|')
+    port1.L1Config.FecErrorInsertion.ErrorType = error_type
+    if error_type == 'codeWords':
+        port1.L1Config.FecErrorInsertion.PerCodeword = 16
+    port1.L1Config.FecErrorInsertion.Continuous = True
+
+    logger.info('Starting Traffic ...')
+    ts = api.control_state()
+    ts.traffic.flow_transmit.state = ts.traffic.flow_transmit.START
+    api.set_control_state(ts)
+    wait(10, "For traffic to start")
+
+    logger.info('Starting FEC Error Insertion')
+    port1.StartFecErrorInsertion()
+    wait(15, "For error insertion to start")
+    # TODO For maxConsecutiveUncorrectableWithoutLossOfLink check link state on DUT
+    flow_metrics = fetch_snappi_flow_metrics(api, ['IPv4 Traffic'])[0]
+    pytest_assert(flow_metrics.frames_tx > 0 and int(flow_metrics.frames_rx_rate) == 0,
+                "FAIL: Rx Port did not stop receiving packets after starting FEC Error Insertion")
+    logger.info(' .. PASSED : Rx Port stopped receiving packets after starting FEC Error Insertion')
+    logger.info('Stopping FEC Error Insertion')
+    port1.StopFecErrorInsertion()
+    wait(15, "For error insertion to stop")
+
+    flow_metrics = fetch_snappi_flow_metrics(api, ['IPv4 Traffic'])[0]
+    pytest_assert(int(flow_metrics.frames_rx_rate) > 0,
+                "FAIL: Rx Port did not resume receiving packets after stopping FEC Error Insertion")
+    logger.info(' .. PASSED : Rx Port resumed receiving packets after stopping FEC Error Insertion')
+    logger.info('Stopping Traffic ...')
+    ts = api.control_state()
+    ts.traffic.flow_transmit.state = ts.traffic.flow_transmit.STOP
+    api.set_control_state(ts)
+    wait(10, "For traffic to stop")
+


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Adding FEC Error Insertion Test Script
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
### OUTPUT:
 

snappi_tests/dataplane/test_fec_error_injection.py::test_fec_error_injection[maxConsecutiveUncorrectableWithoutLossOfLink] 
-------------------------------- live log setup --------------------------------
20:20:18 __init__.set_default                     L0053 INFO   | Completeness level not set during test execution. Setting to default level: CompletenessLevel.basic
20:20:18 __init__.check_test_completeness         L0151 INFO   | Test has no defined levels. Continue without test completeness checks
20:20:18 conftest.enhance_inventory               L0269 INFO   | Inventory file: ['../ansible/snappi-sonic']
20:20:20 ptfhost_utils.run_icmp_responder_session L0296 INFO   | Skip running icmp_responder at session level, it is only for dualtor testbed with active-active mux ports.
20:20:20 __init__.sanity_check                    L0399 INFO   | Skip sanity check according to command line argument
20:20:20 conftest.core_dump_and_config_check      L2466 INFO   | Dumping Disk and Memory Space informataion before test on sonic-s6100-dut1
20:20:21 conftest.core_dump_and_config_check      L2470 INFO   | Collecting core dumps before test on sonic-s6100-dut1
20:20:21 conftest.core_dump_and_config_check      L2479 INFO   | Collecting running config before test on sonic-s6100-dut1
20:20:23 conftest.generate_params_dut_hostname    L1339 INFO   | Using DUTs ['sonic-s6100-dut1'] in testbed 'vms-snappi-sonic'
20:20:23 conftest.set_rand_one_dut_hostname       L0486 INFO   | Randomly select dut sonic-s6100-dut1 for testing
20:20:23 __init__._fixture_generator_decorator    L0081 INFO   | -------------------- fixture enable_packet_aging_after_test setup starts --------------------
20:20:23 __init__._fixture_generator_decorator    L0085 INFO   | -------------------- fixture enable_packet_aging_after_test setup ends --------------------
20:20:23 __init__._fixture_generator_decorator    L0081 INFO   | -------------------- fixture rand_lossless_prio setup starts --------------------
20:20:23 __init__._fixture_generator_decorator    L0085 INFO   | -------------------- fixture rand_lossless_prio setup ends --------------------
20:20:23 __init__._fixture_generator_decorator    L0081 INFO   | -------------------- fixture rand_lossy_prio setup starts --------------------
20:20:23 __init__._fixture_generator_decorator    L0085 INFO   | -------------------- fixture rand_lossy_prio setup ends --------------------
20:20:23 __init__._fixture_generator_decorator    L0081 INFO   | -------------------- fixture start_pfcwd_after_test setup starts --------------------
20:20:23 __init__._fixture_generator_decorator    L0085 INFO   | -------------------- fixture start_pfcwd_after_test setup ends --------------------
20:20:23 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture snappi_api_serv_ip setup starts --------------------
20:20:23 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture snappi_api_serv_ip setup ends --------------------
20:20:23 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture snappi_api_serv_port setup starts --------------------
20:20:23 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture snappi_api_serv_port setup ends --------------------
20:20:23 __init__._fixture_generator_decorator    L0081 INFO   | -------------------- fixture snappi_api setup starts --------------------
20:20:23 __init__._fixture_generator_decorator    L0085 INFO   | -------------------- fixture snappi_api setup ends --------------------
20:20:24 conftest.rand_one_dut_front_end_hostname L0522 INFO   | Randomly select dut sonic-s6100-dut1 for testing
20:20:24 conftest.generate_port_lists             L1408 INFO   | Generate dut_port_map: {'sonic-s6100-dut1': ['sonic-s6100-dut1|Ethernet64', 'sonic-s6100-dut1|Ethernet68']}
20:20:24 conftest.generate_port_lists             L1431 INFO   | Generate port_list: ['sonic-s6100-dut1|Ethernet64', 'sonic-s6100-dut1|Ethernet68']
20:20:24 __init__.loganalyzer                     L0067 INFO   | Log analyzer is disabled
20:20:24 __init__.memory_utilization              L0091 INFO   | Hostname: sonic-s6100-dut1, Hwsku: Accton-AS7726-32X, Platform: x86_64-accton_as7726_32x-r0
20:20:24 __init__.store_fixture_values            L0017 INFO   | store memory_utilization test_fec_error_injection[maxConsecutiveUncorrectableWithoutLossOfLink]
20:20:24 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture snappi_testbed_config setup starts --------------------
20:20:24 snappi_fixtures.__intf_config_static_ip  L0496 INFO   | Configuring Dut: sonic-s6100-dut1 with port Ethernet64 with IP 30.1.1.1/8
20:20:24 snappi_fixtures.__intf_config_static_ip  L0496 INFO   | Configuring Dut: sonic-s6100-dut1 with port Ethernet68 with IP 31.1.1.1/8
20:20:24 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture snappi_testbed_config setup ends --------------------
20:20:24 __init__.pytest_runtest_setup            L0024 INFO   | collect memory before test test_fec_error_injection[maxConsecutiveUncorrectableWithoutLossOfLink]
20:20:24 __init__.pytest_runtest_setup            L0044 INFO   | Before test: collected memory_values {'before_test': {'sonic-s6100-dut1': {'monit': {'memory_usage': 21.1}}}, 'after_test': {'sonic-s6100-dut1': {}}}
-------------------------------- live log call ---------------------------------
20:20:25 connection._warn                         L0332 WARNING| Verification of certificates is disabled
20:20:25 connection._info                         L0329 INFO   | Determining the platform and rest_port using the 10.36.84.33 address...
20:20:25 connection._warn                         L0332 WARNING| Unable to connect to http://10.36.84.33:443.
20:20:25 connection._info                         L0329 INFO   | Connection established to `https://10.36.84.33:443 on linux`
20:20:38 connection._info                         L0329 INFO   | Using IxNetwork api server version 10.25.2406.5
20:20:38 connection._info                         L0329 INFO   | User info IxNetwork/ixnetworkweb/admin-26-2545
20:20:38 snappi_api.info                          L1252 INFO   | snappi-1.17.1
20:20:38 snappi_api.info                          L1252 INFO   | snappi_ixnetwork-1.17.0
20:20:38 snappi_api.info                          L1252 INFO   | ixnetwork_restpy-1.5.0
20:20:39 snappi_api.info                          L1252 INFO   | Config validation 0.006s
20:20:41 snappi_api.info                          L1252 INFO   | Ports configuration 1.454s
20:20:41 snappi_api.info                          L1252 INFO   | Captures configuration 0.132s
20:20:43 snappi_api.info                          L1252 INFO   | Add location hosts [10.36.84.33] 2.241s
20:20:48 snappi_api.info                          L1252 INFO   | Location hosts ready [10.36.84.33] 4.211s
20:20:48 snappi_api.info                          L1252 INFO   | Speed conversion is not require for (port.name, speed) : [('Port 0', 'aresOne-M-OneByEightHundredGigPAM4-106G'), ('Port 1', 'aresOne-M-OneByEightHundredGigPAM4-106G')]
20:20:48 snappi_api.info                          L1252 INFO   | Aggregation mode speed change 0.561s
20:20:53 snappi_api.info                          L1252 INFO   | Location preemption [10.36.84.33/1, 10.36.84.33/2] 0.162s
20:21:21 snappi_api.info                          L1252 INFO   | Location connect [Port 0, Port 1] 28.530s
20:21:21 snappi_api.info                          L1252 INFO   | Location state check [Port 0, Port 1] 0.212s
20:21:21 snappi_api.info                          L1252 INFO   | Location configuration 40.680s
20:22:15 snappi_api.info                          L1252 INFO   | Layer1 configuration 53.893s
20:22:15 snappi_api.info                          L1252 INFO   | Lag Configuration 0.082s
20:22:16 snappi_api.info                          L1252 INFO   | Convert device config : 0.207s
20:22:16 snappi_api.info                          L1252 INFO   | Create IxNetwork device config : 0.000s
20:22:16 snappi_api.info                          L1252 INFO   | Push IxNetwork device config : 0.520s
20:22:16 snappi_api.info                          L1252 INFO   | Devices configuration 0.799s
20:22:18 snappi_api.info                          L1252 INFO   | Flows configuration 1.770s
20:22:24 snappi_api.info                          L1252 INFO   | Start interfaces 6.146s
20:22:25 snappi_api.info                          L1252 INFO   | IxNet - One or more destination MACs or VPNs are invalid or unreachable and the packets configured to be sent to them were not created
20:22:25 snappi_api.info                          L1252 INFO   | IxNet - The Traffic Item was modified. Please perform a Traffic Generate to update the associated traffic Flow Groups
20:22:25 test_fec_error_injection.test_fec_error_ L0057 INFO   | Wait for Arp to Resolve ...
20:22:26 test_fec_error_injection.test_fec_error_ L0061 INFO   | |----------------------------------------|
20:22:26 test_fec_error_injection.test_fec_error_ L0062 INFO   | | Setting FEC Error Type to : maxConsecutiveUncorrectableWithoutLossOfLink |
20:22:26 test_fec_error_injection.test_fec_error_ L0063 INFO   | |----------------------------------------|
20:22:37 test_fec_error_injection.test_fec_error_ L0069 INFO   | Starting Traffic ...
20:22:42 snappi_api.info                          L1252 INFO   | Flows generate/apply 3.797s
20:22:54 snappi_api.info                          L1252 INFO   | Flows clear statistics 12.126s
20:22:54 snappi_api.info                          L1252 INFO   | Captures start 0.000s
20:22:57 snappi_api.info                          L1252 INFO   | Flows start 2.793s
20:22:57 snappi_api.info                          L1252 INFO   | IxNet - The frame size was increased to 66 bytes to accommodate encapsulation requirements.  - The frame size was adjusted to conform to the encapsulation requirements
20:22:57 utilities.wait                           L0117 INFO   | Pause 10 seconds, reason: For traffic to start
20:23:07 test_fec_error_injection.test_fec_error_ L0075 INFO   | Starting FEC Error Insertion
20:23:07 utilities.wait                           L0117 INFO   | Pause 15 seconds, reason: For error insertion to start
20:23:24 test_fec_error_injection.test_fec_error_ L0082 INFO   |  .. PASSED : Rx Port stopped receiving packets after starting FEC Error Insertion
20:23:24 test_fec_error_injection.test_fec_error_ L0083 INFO   | Stopping FEC Error Insertion
20:23:24 utilities.wait                           L0117 INFO   | Pause 15 seconds, reason: For error insertion to stop
20:23:40 test_fec_error_injection.test_fec_error_ L0090 INFO   |  .. PASSED : Rx Port resumed receiving packets after stopping FEC Error Insertion
20:23:40 test_fec_error_injection.test_fec_error_ L0091 INFO   | Stopping Traffic ...
20:23:47 snappi_api.info                          L1252 INFO   | Flows stop 6.653s
20:23:47 utilities.wait                           L0117 INFO   | Pause 10 seconds, reason: For traffic to stop
PASSED                                                                   [ 25%]
------------------------------ live log teardown -------------------------------
20:23:57 __init__.pytest_runtest_teardown         L0049 INFO   | collect memory after test test_fec_error_injection[maxConsecutiveUncorrectableWithoutLossOfLink]
20:23:58 __init__.pytest_runtest_teardown         L0072 INFO   | After test: collected memory_val
