### PR TITLE
[DRAFT] Adding ECN marking test case for AI stress test

### DIFF
--- a/tests/snappi_tests/dataplane/test_ecn.py
+++ b/tests/snappi_tests/dataplane/test_ecn.py
@@ -1,0 +1,103 @@
+from tests.snappi_tests.dataplane.imports import *        # noqa: F401
+from tests.common.snappi_tests.snappi_helpers import wait_for_arp, fetch_snappi_flow_metrics      # noqa: F401
+from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port, \
+    snappi_api, get_snappi_ports, is_snappi_multidut, get_snappi_ports_single_dut, get_snappi_ports_multi_dut, \
+    snappi_dut_base_config   # noqa: F401
+from snappi_tests.dataplane.files.helper import setup_snappi_port_configs, get_ti_stats, get_fanout_port_groups, create_ecn_snappi_config, create_traffic_items
+from tests.common.snappi_tests.read_pcap import get_ipv4_pkts
+from tests.common.snappi_tests.common_helpers import packet_capture, config_capture_pkt
+from tests.common.snappi_tests.read_pcap import is_ecn_marked
+from tests.common.snappi_tests.variables import pfcQueueGroupSize, pfcQueueValueDict
+
+pytestmark = [pytest.mark.topology('tgen')]
+logger = logging.getLogger(__name__)
+
+
+def test_ecn(duthost,
+             snappi_api,
+             get_snappi_ports,
+             setup_snappi_port_configs,
+             fanout_graph_facts_multidut):
+    """
+    Test to check if packets get dropped on injecting fec errors
+    Note: fanout_per_port is the number of fanouts per fron panel port
+          Example: For running the test on 400g fanout mode of a 800g port,
+          fanout_per_port is 2
+    """
+    snappi_extra_params = SnappiTestParams()
+    snappi_ports = get_snappi_ports
+    snappi_ports = setup_snappi_port_configs
+    tx_ports = setup_snappi_port_configs[1:3]
+    rx_ports = [setup_snappi_port_configs[3]]
+    config, tx_names, rx_names = create_ecn_snappi_config(snappi_api, tx_ports, rx_ports)
+    api = snappi_api
+    for tx_name in tx_names:
+        config = create_traffic_items(config, tx_name, rx_names[0], line_rate=55)
+    api.set_config(config)
+
+    packet_capture_file = "ECN_capture"
+    logger.info("Packet capture file: {}.pcapng".format(packet_capture_file))
+    packet_capture_ports = [config.ports[-1].name]
+    config_capture_pkt(testbed_config=config,
+                    port_names=packet_capture_ports,
+                    capture_type=packet_capture.IP_CAPTURE,
+                    capture_name=packet_capture_file)
+    
+    ixnetwork = api._ixnetwork
+    ixnetwork.Vport.find(Name = packet_capture_ports[0]).Capture.HardwareEnabled = True
+    ixnetwork.Vport.find(Name = packet_capture_ports[0]).Capture.SoftwareEnabled = True
+    ixnetwork.Vport.find(Name = packet_capture_ports[0]).Capture.CaptureMode = 'captureContinuousMode'
+    ixnet_ports = ixnetwork.Vport.find()
+    for port in ixnet_ports:
+        port.Type = 'aresOneMFcoe'
+        port.L1Config.AresOneM.Fcoe.PfcQueueGroups = [pfcQueueValueDict[key] for key in pfcQueueValueDict]
+    logger.info('Starting All protocols')
+    ixnetwork.StartAllProtocols()
+    wait(10, "For Protocols To start")
+    trafficItem = ixnetwork.Traffic.TrafficItem.find()
+    for ti in trafficItem:
+        ti.ConfigElement.find()[0].TransmissionControl.Type = 'fixedFrameCount'
+        ti.ConfigElement.find()[0].TransmissionControl.FrameCount = 1000
+
+    logger.info("Starting packet capture ...")
+    cs = api.control_state()
+    cs.port.capture.port_names = packet_capture_ports
+    cs.port.capture.state = cs.port.capture.START
+    api.set_control_state(cs)
+    wait(5, "To start capture")
+
+    logger.info("Starting transmit on all flows ...")
+    ts = api.control_state()
+    ts.traffic.flow_transmit.state = ts.traffic.flow_transmit.START
+    api.set_control_state(ts)
+    wait(10, "To send traffic")
+    logger.info(
+    "Dumping Traffic Item statistics :\n {}".format(
+        tabulate(get_ti_stats(ixnetwork), headers="keys", tablefmt="psql")
+    )
+    )
+    logger.info("Stopping transmit on all flows ...")
+    ts = api.control_state()
+    ts.traffic.flow_transmit.state = ts.traffic.flow_transmit.STOP
+    api.set_control_state(ts)
+    wait(20, "To stop traffic")
+    logger.info("Stopping packet capture ...")
+    request = api.capture_request()
+    request.port_name = packet_capture_ports[0]
+    wait(10, "ecc ")
+    cs = api.control_state()
+    cs.port.capture.state = cs.port.capture.STOP
+    api.set_control_state(cs)
+    logger.info("Retrieving and saving packet capture to {}.pcapng".format(packet_capture_file))
+    wait(10, "To load capture")
+    pcap_bytes = api.get_capture(request)
+    with open(packet_capture_file + ".pcapng", 'wb') as fid:
+        fid.write(pcap_bytes.getvalue())
+
+    # packet_capture_file = "Rx_0 - Data"
+    ip_pkts = get_ipv4_pkts(packet_capture_file + ".pcapng")
+    # Check if the first packet is ECN marked
+    pytest_assert(is_ecn_marked(ip_pkts[0]), "The first packet should be marked")
+    # Check if the last packet is not ECN marked
+    pytest_assert(not is_ecn_marked(ip_pkts[-1]),
+                  "The last packet should not be marked")

--- a/tests/snappi_tests/dataplane/test_ecn_marking.py
+++ b/tests/snappi_tests/dataplane/test_ecn_marking.py
@@ -1,0 +1,134 @@
+from tests.snappi_tests.dataplane.imports import *  # noqa: F401
+from tests.common.snappi_tests.snappi_helpers import (
+    wait_for_arp,
+    fetch_snappi_flow_metrics,
+)  # noqa: F401
+from tests.common.snappi_tests.snappi_fixtures import (
+    snappi_api_serv_ip,
+    snappi_api_serv_port,
+    snappi_api,
+    get_snappi_ports,
+    is_snappi_multidut,
+    get_snappi_ports_single_dut,
+    get_snappi_ports_multi_dut,
+    snappi_dut_base_config,
+)  # noqa: F401
+from snappi_tests.dataplane.files.helper import (
+    setup_snappi_port_configs,
+    get_ti_stats,
+    get_fanout_port_groups,
+    create_snappi_config,
+    create_traffic_items,
+)
+from tests.common.snappi_tests.read_pcap import get_ipv4_pkts
+from tests.common.snappi_tests.common_helpers import packet_capture, config_capture_pkt
+from tests.common.snappi_tests.read_pcap import is_ecn_marked
+from tests.common.snappi_tests.variables import pfcQueueGroupSize, pfcQueueValueDict
+
+pytestmark = [pytest.mark.topology("tgen")]
+logger = logging.getLogger(__name__)
+
+
+def test_ecn_marking(
+    duthost,
+    snappi_api,                   # noqa: F811
+    get_snappi_ports,             # noqa: F811
+    setup_snappi_port_configs,    # noqa: F811
+    fanout_graph_facts_multidut,
+):
+    """
+    Test to check if packets get dropped on injecting fec errors
+    Note: fanout_per_port is the number of fanouts per fron panel port
+          Example: For running the test on 400g fanout mode of a 800g port,
+          fanout_per_port is 2
+    """
+    snappi_extra_params = SnappiTestParams()
+    snappi_ports = get_snappi_ports
+    snappi_ports = setup_snappi_port_configs
+    tx_ports = setup_snappi_port_configs[1:3]
+    rx_ports = [setup_snappi_port_configs[3]]
+    config, tx_names, rx_names = create_snappi_config(
+        snappi_api, tx_ports, rx_ports, is_rdma=True
+    )
+    api = snappi_api
+    for tx_name in tx_names:
+        config = create_traffic_items(
+            config, tx_name, rx_names[0], line_rate=55, is_rdma=True
+        )
+    api.set_config(config)
+
+    packet_capture_file = "ECN_capture"
+    logger.info("Packet capture file: {}.pcapng".format(packet_capture_file))
+    packet_capture_ports = [config.ports[-1].name]
+    config_capture_pkt(
+        testbed_config=config,
+        port_names=packet_capture_ports,
+        capture_type=packet_capture.IP_CAPTURE,
+        capture_name=packet_capture_file,
+    )
+
+    ixnetwork = api._ixnetwork
+    ixnetwork.Vport.find(Name=packet_capture_ports[0]).Capture.HardwareEnabled = True
+    ixnetwork.Vport.find(Name=packet_capture_ports[0]).Capture.SoftwareEnabled = True
+    ixnetwork.Vport.find(Name=packet_capture_ports[0]).Capture.CaptureMode = (
+        "captureContinuousMode"
+    )
+    ixnet_ports = ixnetwork.Vport.find()
+    for port in ixnet_ports:
+        port.Type = "aresOneMFcoe"
+        port.L1Config.AresOneM.Fcoe.PfcQueueGroups = [
+            pfcQueueValueDict[key] for key in pfcQueueValueDict
+        ]
+    logger.info("Starting All protocols")
+    ixnetwork.StartAllProtocols()
+
+    wait(10, "For Protocols To start")
+    trafficItem = ixnetwork.Traffic.TrafficItem.find()
+    for ti in trafficItem:
+        ti.ConfigElement.find()[0].TransmissionControl.Type = "fixedDuration"
+        ti.ConfigElement.find()[0].TransmissionControl.Duration = 5
+    logger.info("Starting packet capture ...")
+    cs = api.control_state()
+    cs.port.capture.port_names = packet_capture_ports
+    cs.port.capture.state = cs.port.capture.START
+    api.set_control_state(cs)
+    wait(5, "To start capture")
+
+    logger.info("Starting transmit on all flows ...")
+    ts = api.control_state()
+    ts.traffic.flow_transmit.state = ts.traffic.flow_transmit.START
+    api.set_control_state(ts)
+    wait(10, "To send traffic")
+    logger.info(
+        "Dumping Traffic Item statistics :\n {}".format(
+            tabulate(get_ti_stats(ixnetwork), headers="keys", tablefmt="psql")
+        )
+    )
+    logger.info("Stopping transmit on all flows ...")
+    ts = api.control_state()
+    ts.traffic.flow_transmit.state = ts.traffic.flow_transmit.STOP
+    api.set_control_state(ts)
+    wait(20, "To stop traffic")
+    logger.info("Stopping packet capture ...")
+    request = api.capture_request()
+    request.port_name = packet_capture_ports[0]
+    wait(20, "ecc ")
+    cs = api.control_state()
+    cs.port.capture.state = cs.port.capture.STOP
+    api.set_control_state(cs)
+    logger.info(
+        "Retrieving and saving packet capture to {}.pcapng".format(packet_capture_file)
+    )
+    wait(20, "To load capture")
+    pcap_bytes = api.get_capture(request)
+    with open(packet_capture_file + ".pcapng", "wb") as fid:
+        fid.write(pcap_bytes.getvalue())
+
+    # packet_capture_file = "Rx_0 - Data"
+    ip_pkts = get_ipv4_pkts(packet_capture_file + ".pcapng")
+    # Check if the first packet is ECN marked
+    pytest_assert(is_ecn_marked(ip_pkts[0]), "The first packet should be marked")
+    # Check if the last packet is not ECN marked
+    pytest_assert(
+        not is_ecn_marked(ip_pkts[-1]), "The last packet should not be marked"
+    )


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Adding ECN testcase for AI stress test

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
### Output
snappi_tests/dataplane/test_ecn.py::test_ecn 
--------------------------------------------------------------------------------------------------------------------------------------------- live log setup ----------------------------------------------------------------------------------------------------------------------------------------------
17:40:26 __init__.set_default                     L0053 INFO   | Completeness level not set during test execution. Setting to default level: CompletenessLevel.basic
17:40:26 __init__.check_test_completeness         L0151 INFO   | Test has no defined levels. Continue without test completeness checks
17:40:26 conftest.enhance_inventory               L0263 INFO   | Inventory file: ['../ansible/snappi-sonic']
17:40:29 ptfhost_utils.run_icmp_responder_session L0296 INFO   | Skip running icmp_responder at session level, it is only for dualtor testbed with active-active mux ports.
17:40:29 __init__.sanity_check                    L0406 INFO   | Skip sanity check according to command line argument
17:40:29 conftest.core_dump_and_config_check      L2366 INFO   | Dumping Disk and Memory Space informataion before test on sonic-s6100-dut1
17:40:29 conftest.core_dump_and_config_check      L2370 INFO   | Collecting core dumps before test on sonic-s6100-dut1
17:40:30 conftest.core_dump_and_config_check      L2379 INFO   | Collecting running config before test on sonic-s6100-dut1
17:40:32 conftest.generate_params_dut_hostname    L1322 INFO   | Using DUTs ['sonic-s6100-dut1'] in testbed 'vms-snappi-sonic'
17:40:32 conftest.set_rand_one_dut_hostname       L0539 INFO   | Randomly select dut sonic-s6100-dut1 for testing
17:40:32 __init__._fixture_generator_decorator    L0081 INFO   | -------------------- fixture enable_packet_aging_after_test setup starts --------------------
17:40:32 __init__._fixture_generator_decorator    L0085 INFO   | -------------------- fixture enable_packet_aging_after_test setup ends --------------------
17:40:32 __init__._fixture_generator_decorator    L0081 INFO   | -------------------- fixture rand_lossless_prio setup starts --------------------
17:40:32 __init__._fixture_generator_decorator    L0085 INFO   | -------------------- fixture rand_lossless_prio setup ends --------------------
17:40:32 __init__._fixture_generator_decorator    L0081 INFO   | -------------------- fixture rand_lossy_prio setup starts --------------------
17:40:32 __init__._fixture_generator_decorator    L0085 INFO   | -------------------- fixture rand_lossy_prio setup ends --------------------
17:40:32 __init__._fixture_generator_decorator    L0081 INFO   | -------------------- fixture start_pfcwd_after_test setup starts --------------------
17:40:32 __init__._fixture_generator_decorator    L0085 INFO   | -------------------- fixture start_pfcwd_after_test setup ends --------------------
17:40:32 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture snappi_api_serv_ip setup starts --------------------
17:40:32 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture snappi_api_serv_ip setup ends --------------------
17:40:32 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture snappi_api_serv_port setup starts --------------------
17:40:32 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture snappi_api_serv_port setup ends --------------------
17:40:32 __init__._fixture_generator_decorator    L0081 INFO   | -------------------- fixture snappi_api setup starts --------------------
17:40:32 __init__._fixture_generator_decorator    L0085 INFO   | -------------------- fixture snappi_api setup ends --------------------
17:40:32 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture get_snappi_ports setup starts --------------------
17:40:33 conftest.rand_one_dut_front_end_hostname L0575 INFO   | Randomly select dut sonic-s6100-dut1 for testing
17:40:33 conftest.generate_port_lists             L1391 INFO   | Generate dut_port_map: {'sonic-s6100-dut1': ['sonic-s6100-dut1|Ethernet0', 'sonic-s6100-dut1|Ethernet8', 'sonic-s6100-dut1|Ethernet40', 'sonic-s6100-dut1|Ethernet48', 'sonic-s6100-dut1|Ethernet56', 'sonic-s6100-dut1|Ethernet124']}
17:40:33 conftest.generate_port_lists             L1414 INFO   | Generate port_list: ['sonic-s6100-dut1|Ethernet0', 'sonic-s6100-dut1|Ethernet8', 'sonic-s6100-dut1|Ethernet40', 'sonic-s6100-dut1|Ethernet48', 'sonic-s6100-dut1|Ethernet56', 'sonic-s6100-dut1|Ethernet124']
17:40:33 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture get_snappi_ports_single_dut setup starts --------------------
17:40:33 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture get_snappi_ports_single_dut setup ends --------------------
17:40:33 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture get_snappi_ports setup ends --------------------
17:40:33 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture setup_snappi_port_configs setup starts --------------------
17:40:34 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture setup_snappi_port_configs setup ends --------------------
17:40:35 __init__.loganalyzer                     L0067 INFO   | Log analyzer is disabled
17:40:35 __init__.memory_utilization              L0091 INFO   | Hostname: sonic-s6100-dut1, Hwsku: Arista-7060X6-64PE-C256S2, Platform: x86_64-arista_7060x6_64pe
17:40:35 __init__.store_fixture_values            L0017 INFO   | store memory_utilization test_ecn
17:40:35 __init__.pytest_runtest_setup            L0024 INFO   | collect memory before test test_ecn
17:40:35 __init__.pytest_runtest_setup            L0044 INFO   | Before test: collected memory_values {'before_test': {'sonic-s6100-dut1': {'monit': {'memory_usage': 14.2}}}, 'after_test': {'sonic-s6100-dut1': {}}}
---------------------------------------------------------------------------------------------------------------------------------------------- live log call ----------------------------------------------------------------------------------------------------------------------------------------------
17:40:35 connection._warn                         L0332 WARNING| Verification of certificates is disabled
17:40:35 connection._info                         L0329 INFO   | Determining the platform and rest_port using the 10.36.84.34 address...
17:40:35 connection._warn                         L0332 WARNING| Unable to connect to http://10.36.84.34:443.
17:40:35 connection._info                         L0329 INFO   | Connection established to `https://10.36.84.34:443 on linux`
17:40:58 connection._info                         L0329 INFO   | Using IxNetwork api server version 10.80.2411.100
17:40:58 connection._info                         L0329 INFO   | User info IxNetwork/ixnetworkweb/admin-3-6081
17:41:01 snappi_api.info                          L1252 INFO   | snappi-1.17.1
17:41:01 snappi_api.info                          L1252 INFO   | snappi_ixnetwork-1.17.0
17:41:01 snappi_api.info                          L1252 INFO   | ixnetwork_restpy-1.5.0
17:41:02 snappi_api.info                          L1252 INFO   | Config validation 0.010s
17:41:04 snappi_api.info                          L1252 INFO   | Ports configuration 1.575s
17:41:04 snappi_api.info                          L1252 INFO   | Captures configuration 0.174s
17:41:17 snappi_api.info                          L1252 INFO   | Add location hosts [10.36.84.31] 12.229s
17:41:19 snappi_api.info                          L1252 INFO   | Location hosts ready [10.36.84.31] 2.158s
17:41:20 snappi_api.info                          L1252 INFO   | Speed conversion is not require for (port.name, speed) : [('Tx_0', 'aresOne-M-EightByOneHundredGigPAM4-106G'), ('Tx_1', 'aresOne-M-EightByOneHundredGigPAM4-106G'), ('Rx_0', 'aresOne-M-EightByOneHundredGigPAM4-106G')]
17:41:20 snappi_api.info                          L1252 INFO   | Aggregation mode speed change 1.475s
17:41:21 snappi_api.info                          L1252 INFO   | Location preemption [10.36.84.31/1.2, 10.36.84.31/1.3, 10.36.84.31/1.4] 0.187s
17:41:58 snappi_api.info                          L1252 INFO   | Location connect [Tx_0, Tx_1, Rx_0] 37.342s
17:41:59 snappi_api.info                          L1252 INFO   | Location state check [Tx_0, Tx_1, Rx_0] 0.247s
17:41:59 snappi_api.info                          L1252 INFO   | Location configuration 54.634s
17:42:50 snappi_api.info                          L1252 INFO   | Layer1 configuration 51.312s
17:42:50 snappi_api.info                          L1252 INFO   | Lag Configuration 0.079s
17:42:51 snappi_api.info                          L1252 INFO   | Convert device config : 0.389s
17:42:51 snappi_api.info                          L1252 INFO   | Create IxNetwork device config : 0.000s
17:42:52 snappi_api.info                          L1252 INFO   | Push IxNetwork device config : 1.414s
17:42:52 snappi_api.info                          L1252 INFO   | Devices configuration 1.873s
17:42:58 snappi_api.info                          L1252 INFO   | Flows configuration 5.783s
17:43:12 snappi_api.info                          L1252 INFO   | Start interfaces 13.884s
17:43:12 snappi_api.info                          L1252 INFO   | IxNet - One or more destination MACs or VPNs are invalid or unreachable and the packets configured to be sent to them were not created
17:43:12 snappi_api.info                          L1252 INFO   | IxNet - The Traffic Item was modified. Please perform a Traffic Generate to update the associated traffic Flow Groups
17:43:12 test_ecn.test_ecn                        L0039 INFO   | Packet capture file: ECN_capture.pcapng
17:43:50 test_ecn.test_ecn                        L0054 INFO   | Starting All protocols
17:43:51 utilities.wait                           L0117 INFO   | Pause 10 seconds, reason: For Protocols To start
17:44:01 test_ecn.test_ecn                        L0058 INFO   | Starting packet capture ...
17:44:09 snappi_api.info                          L1252 INFO   | Captures start 7.310s
17:44:09 utilities.wait                           L0117 INFO   | Pause 5 seconds, reason: To start capture
17:44:14 test_ecn.test_ecn                        L0065 INFO   | Starting transmit on all flows ...
17:44:19 snappi_api.info                          L1252 INFO   | Flows generate/apply 3.970s
17:44:34 snappi_api.info                          L1252 INFO   | Flows clear statistics 14.095s
17:44:39 snappi_api.info                          L1252 INFO   | Captures start 5.167s
17:44:42 snappi_api.info                          L1252 INFO   | Flows start 2.919s
17:44:42 utilities.wait                           L0117 INFO   | Pause 10 seconds, reason: To send traffic
17:44:53 test_ecn.test_ecn                        L0071 INFO   | Dumping Traffic Item statistics :
 +----+-------------+-------------+----------------+----------+-----------------+-----------------+
|    |   Tx Frames |   Rx Frames |   Frames Delta |   Loss % |   Tx Frame Rate |   Rx Frame Rate |
|----+-------------+-------------+----------------+----------+-----------------+-----------------|
|  0 |    65162985 |    59361794 |        5801191 |    8.903 |     6.58525e+06 |     5.99892e+06 |
|  1 |    65162985 |    59117307 |        6045678 |    9.278 |     6.58525e+06 |     5.97436e+06 |
+----+-------------+-------------+----------------+----------+-----------------+-----------------+
17:44:53 test_ecn.test_ecn                        L0076 INFO   | Stopping transmit on all flows ...
17:45:00 snappi_api.info                          L1252 INFO   | Flows stop 6.486s
17:45:00 test_ecn.test_ecn                        L0081 INFO   | Stopping packet capture ...
17:45:00 test_ecn.test_ecn                        L0087 INFO   | Retrieving and saving packet capture to ECN_capture.pcapng
17:45:00 utilities.wait                           L0117 INFO   | Pause 10 seconds, reason: To load capture
17:48:00 snappi_api.info                          L1252 INFO   | Captures stop 86.891s
17:48:07 read_pcap.get_ipv4_pkts                  L0138 INFO   | Reading packets from pcap file -> ECN_capture.pcapng
17:48:07 read_pcap.get_ipv4_pkts                  L0139 INFO   | Extracting ethernet frames from pcap file
17:48:07 read_pcap.is_ecn_marked                  L0161 INFO   | Checking if the packet is ECN congestion marked
17:48:07 read_pcap.is_ecn_marked                  L0161 INFO   | Checking if the packet is ECN congestion marked
PASSED                                                                                                                                                                                                                                                                                              [100%]
-------------------------------------------------------------------------------------------------------------------------------------------- live log teardown 
